### PR TITLE
update to interop-config 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "sandrokeil/interop-config": "^1.0",
+        "sandrokeil/interop-config": "^2.0",
         "phpunit/phpunit": "^5.7",
         "phpspec/prophecy": "dev-patch-1 as 1.6.2",
         "prooph/php-cs-fixer-config": "^0.1.1",
@@ -35,7 +35,7 @@
         "ext-pdo_pgsql": "For usage with PostgreSQL"
     },
     "conflict": {
-        "sandrokeil/interop-config": "<1.0"
+        "sandrokeil/interop-config": "<2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Container/AbstractEventStoreFactory.php
+++ b/src/Container/AbstractEventStoreFactory.php
@@ -117,12 +117,12 @@ abstract class AbstractEventStoreFactory implements
 
     abstract protected function eventStoreClassName(): string;
 
-    public function dimensions(): array
+    public function dimensions(): iterable
     {
         return ['prooph', 'event_store'];
     }
 
-    public function mandatoryOptions(): array
+    public function mandatoryOptions(): iterable
     {
         return [
             'persistence_strategy',


### PR DESCRIPTION
The interesting thing is, we must not update `AbstractEventStoreFactory.php`. `dimensions(): array` is still valid, but for the consistency.