### PR TITLE
Convert PostgreSQL payload column from JSONB to JSON.

### DIFF
--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -30,7 +30,7 @@ CREATE TABLE $tableName (
     no SERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
-    payload JSONB NOT NULL,
+    payload JSON NOT NULL,
     metadata JSONB NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (no),

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -29,7 +29,7 @@ CREATE TABLE $tableName (
     no SERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
-    payload JSONB NOT NULL,
+    payload JSON NOT NULL,
     metadata JSONB NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (no),

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -29,7 +29,7 @@ CREATE TABLE $tableName (
     no SERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
-    payload JSONB NOT NULL,
+    payload JSON NOT NULL,
     metadata JSONB NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (no),


### PR DESCRIPTION
Fixes #27: Since the payload column simply stores JSON data it is more efficient to use the JSON datatype of PostgreSQL as no conversion happens when the data is getting stored or read.