### PR TITLE
adds missing phpunit group annotations to container test classes

### DIFF
--- a/tests/Container/MySQLEventStoreFactoryTest.php
+++ b/tests/Container/MySQLEventStoreFactoryTest.php
@@ -26,6 +26,9 @@ use Prooph\EventStore\PDO\PersistenceStrategy;
 use Prooph\EventStore\Plugin\Plugin;
 use ProophTest\EventStore\PDO\TestUtil;
 
+/**
+ * @group pdo_mysql
+ */
 final class MySQLEventStoreFactoryTest extends TestCase
 {
     /**

--- a/tests/Container/PostgresEventStoreFactoryTest.php
+++ b/tests/Container/PostgresEventStoreFactoryTest.php
@@ -27,6 +27,9 @@ use Prooph\EventStore\Plugin\Plugin;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
 use ProophTest\EventStore\PDO\TestUtil;
 
+/**
+ * @group pdo_pgsql
+ */
 final class PostgresEventStoreFactoryTest extends TestCase
 {
     /**


### PR DESCRIPTION
UnitTests would fail with messages like 

> "Extension "pdo_pgsql" is not loaded" 
