### PR TITLE
adds missing phpunit group annotations to container test classes

### DIFF
--- a/phpunit.xml.pdo_mysql
+++ b/phpunit.xml.pdo_mysql
@@ -18,6 +18,7 @@
         <whitelist>
             <directory>./src/</directory>
             <exclude>
+                <file>./src/Container/PostgresEventStoreFactory.php</file>
                 <file>./src/PersistenceStrategy/PostgresAggregateStreamStrategy.php</file>
                 <file>./src/PersistenceStrategy/PostgresSimpleStreamStrategy.php</file>
                 <file>./src/PersistenceStrategy/PostgresSingleStreamStrategy.php</file>

--- a/phpunit.xml.pdo_pgsql
+++ b/phpunit.xml.pdo_pgsql
@@ -18,6 +18,7 @@
         <whitelist>
             <directory>./src/</directory>
             <exclude>
+                <file>./src/Container/MySqlEventStoreFactory.php</file>
                 <file>./src/PersistenceStrategy/MySqlAggregateStreamStrategy.php</file>
                 <file>./src/PersistenceStrategy/MySqlSimpleStreamStrategy.php</file>
                 <file>./src/PersistenceStrategy/MySqlSingleStreamStrategy.php</file>

--- a/tests/Container/MySqlEventStoreFactoryTest.php
+++ b/tests/Container/MySqlEventStoreFactoryTest.php
@@ -26,6 +26,9 @@ use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Plugin\Plugin;
 use ProophTest\EventStore\Pdo\TestUtil;
 
+/**
+ * @group pdo_mysql
+ */
 final class MySqlEventStoreFactoryTest extends TestCase
 {
     /**

--- a/tests/Container/PostgresEventStoreFactoryTest.php
+++ b/tests/Container/PostgresEventStoreFactoryTest.php
@@ -27,6 +27,9 @@ use Prooph\EventStore\Plugin\Plugin;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
 use ProophTest\EventStore\Pdo\TestUtil;
 
+/**
+ * @group pdo_pgsql
+ */
 final class PostgresEventStoreFactoryTest extends TestCase
 {
     /**


### PR DESCRIPTION
UnitTests would fail with messages like

> "Extension "pdo_pgsql" is not loaded"