### PR TITLE
updates minimum MySQL server version to 5.7.9 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 - PHP >= 7.1
 - PDO_MySQL Extension or PDO_PGSQL Extension
 
-For MySQL you need server version >= 5.7.8.
+For MySQL you need server version >= 5.7.9.
 For Postgres you need server version >= 9.4.
 
 Setup


### PR DESCRIPTION
Since we are using JSON_EXTRACT shorthands like here:
https://github.com/prooph/pdo-event-store/blob/0dc302252b3fbde292cb68fafdd1579e1907fabf/src/MySqlEventStore.php#L285

MySQL Server Version >= 5.7.9 is required.

See https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-column-path
> In MySQL 5.7.9 and later, the -> operator serves as an alias for the JSON_EXTRACT() function when used with two arguments, a column identifier on the left and a JSON path on the right that is evaluated against the JSON document (the column value). You can use such expressions in place of column identifiers wherever they occur in SQL statements.