### PR TITLE
SQL Query improvements

### DIFF
--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -161,16 +161,15 @@ EOT;
     public function hasStream(StreamName $streamName): bool
     {
         $sql = <<<EOT
-SELECT stream_name FROM $this->eventStreamsTable
+SELECT COUNT(1) FROM $this->eventStreamsTable
 WHERE real_stream_name = :streamName;
 EOT;
+
         $statement = $this->connection->prepare($sql);
 
         $statement->execute(['streamName' => $streamName->toString()]);
 
-        $stream = $statement->fetch(PDO::FETCH_OBJ);
-
-        return false !== $stream;
+        return '1' === $statement->fetchColumn();
     }
 
     public function create(Stream $stream): void

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -158,16 +158,15 @@ EOT;
     public function hasStream(StreamName $streamName): bool
     {
         $sql = <<<EOT
-SELECT stream_name FROM $this->eventStreamsTable
+SELECT COUNT(1) FROM $this->eventStreamsTable
 WHERE real_stream_name = :streamName;
 EOT;
+
         $statement = $this->connection->prepare($sql);
 
         $statement->execute(['streamName' => $streamName->toString()]);
 
-        $stream = $statement->fetch(PDO::FETCH_OBJ);
-
-        return false !== $stream;
+        return 1 === $statement->fetchColumn();
     }
 
     public function create(Stream $stream): void


### PR DESCRIPTION
This PR provides changes on queries for hasStream requests on MySQL and Postgres.

On MySQL, this query could be done only with index file and without fetching real data from db-table.
Since the `stream_name` is not relevant there is no need to fetch it, which results in a performance improvement.

Not sure about Postgres, but should be the same how on MySQL.

Note that fetchColumn for MySQL would return a string, but an integer on Postgres.