### PR TITLE
use prepared load statements

### DIFF
--- a/scripts/mysql/01_event_streams_table.sql
+++ b/scripts/mysql/01_event_streams_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `event_streams` (
-  `no` INT(11) NOT NULL AUTO_INCREMENT,
+  `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
   `real_stream_name` VARCHAR(150) NOT NULL,
   `stream_name` CHAR(41) NOT NULL,
   `metadata` JSON,

--- a/scripts/mysql/02_projections_table.sql
+++ b/scripts/mysql/02_projections_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `projections` (
-  `no` INT(11) NOT NULL AUTO_INCREMENT,
+  `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(150) NOT NULL,
   `position` JSON,
   `state` JSON,

--- a/scripts/postgres/01_event_streams_table.sql
+++ b/scripts/postgres/01_event_streams_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE event_streams (
-  no SERIAL,
+  no BIGSERIAL,
   real_stream_name VARCHAR(150) NOT NULL,
   stream_name CHAR(41) NOT NULL,
   metadata JSONB,

--- a/scripts/postgres/02_projections_table.sql
+++ b/scripts/postgres/02_projections_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE projections (
-  no SERIAL,
+  no BIGSERIAL,
   name VARCHAR(150) NOT NULL,
   position JSONB,
   state JSONB,

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -283,7 +283,7 @@ EOT;
             $values[$parameter] = $value;
         }
 
-        $where[] = "`no` >= :fromNumber";
+        $where[] = '`no` >= :fromNumber';
 
         $whereCondition = implode(' AND ', $where);
         $limit = min($count, $this->loadBatchSize);
@@ -358,7 +358,7 @@ EOT;
             $values[$parameter] = $value;
         }
 
-        $where[] = "`no` <= :fromNumber";
+        $where[] = '`no` <= :fromNumber';
 
         $whereCondition = implode(' AND ', $where);
         $limit = min($count, $this->loadBatchSize);

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -265,40 +265,44 @@ EOT;
 
         $tableName = $this->persistenceStrategy->generateTableName($streamName);
 
-        $sql = [
-            'from' => "SELECT * FROM $tableName",
-            'orderBy' => 'ORDER BY no ASC',
-        ];
+        $where = [];
+        $values = [];
 
-        foreach ($metadataMatcher->data() as $match) {
+        foreach ($metadataMatcher->data() as $key => $match) {
             $field = $match['field'];
             $operator = $match['operator']->getValue();
             $value = $match['value'];
+            $parameter = ':metadata_'.$key;
 
             if (is_bool($value)) {
-                $value = var_export($value, true);
-            } elseif (is_string($value)) {
-                $value = $this->connection->quote($value);
+                $where[] = "metadata->\"$.$field\" $operator ".var_export($value, true);
+                continue;
             }
 
-            $sql['where'][] = "metadata->\"$.$field\" $operator $value";
+            $where[] = "metadata->\"$.$field\" $operator $parameter";
+            $values[$parameter] = $value;
         }
 
-        $limit = $count < $this->loadBatchSize
-            ? $count
-            : $this->loadBatchSize;
+        $where[] = "`no` >= :fromNumber";
 
-        $query = $sql['from'] . " WHERE no >= $fromNumber";
+        $whereCondition = implode(' AND ', $where);
+        $limit = min($count, $this->loadBatchSize);
 
-        if (isset($sql['where'])) {
-            $query .= ' AND ';
-            $query .= implode(' AND ', $sql['where']);
-        }
-
-        $query .= ' ' . $sql['orderBy'];
-        $query .= " LIMIT $limit;";
+        $query = <<<EOT
+SELECT * FROM $tableName
+WHERE $whereCondition
+ORDER BY `no` ASC
+LIMIT :limit;
+EOT;
 
         $statement = $this->connection->prepare($query);
+        $statement->bindValue(':fromNumber', $fromNumber, PDO::PARAM_INT);
+        $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+
+        foreach ($values as $parameter => $value) {
+            $statement->bindValue($parameter, $value, is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR);
+        }
+
         $statement->setFetchMode(PDO::FETCH_OBJ);
         $statement->execute();
 
@@ -312,7 +316,6 @@ EOT;
                 $this->connection,
                 $statement,
                 $this->messageFactory,
-                $sql,
                 $this->loadBatchSize,
                 $fromNumber,
                 $count,
@@ -337,40 +340,43 @@ EOT;
 
         $tableName = $this->persistenceStrategy->generateTableName($streamName);
 
-        $sql = [
-            'from' => "SELECT * FROM $tableName",
-            'orderBy' => 'ORDER BY no DESC',
-        ];
+        $where = [];
+        $values = [];
 
-        foreach ($metadataMatcher->data() as $match) {
+        foreach ($metadataMatcher->data() as $key => $match) {
             $field = $match['field'];
             $operator = $match['operator']->getValue();
             $value = $match['value'];
+            $parameter = ':metadata_'.$key;
 
             if (is_bool($value)) {
-                $value = var_export($value, true);
-            } elseif (is_string($value)) {
-                $value = $this->connection->quote($value);
+                $where[] = "metadata->\"$.$field\" $operator ".var_export($value, true);
+                continue;
             }
 
-            $sql['where'][] = "metadata->\"$.$field\" $operator $value";
+            $where[] = "metadata->\"$.$field\" $operator $parameter";
+            $values[$parameter] = $value;
         }
 
-        $limit = $count < $this->loadBatchSize
-            ? $count
-            : $this->loadBatchSize;
+        $where[] = "`no` <= :fromNumber";
 
-        $query = $sql['from'] . " WHERE no <= $fromNumber";
+        $whereCondition = implode(' AND ', $where);
+        $limit = min($count, $this->loadBatchSize);
 
-        if (isset($sql['where'])) {
-            $query .= ' AND ';
-            $query .= implode(' AND ', $sql['where']);
-        }
-
-        $query .= ' ' . $sql['orderBy'];
-        $query .= " LIMIT $limit;";
+        $query = <<<EOT
+SELECT * FROM $tableName
+WHERE $whereCondition
+ORDER BY `no` DESC
+LIMIT :limit;
+EOT;
 
         $statement = $this->connection->prepare($query);
+        $statement->bindValue(':fromNumber', $fromNumber, PDO::PARAM_INT);
+        $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+
+        foreach ($values as $parameter => $value) {
+            $statement->bindValue($parameter, $value, is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR);
+        }
 
         $statement->setFetchMode(PDO::FETCH_OBJ);
         $statement->execute();
@@ -385,7 +391,6 @@ EOT;
                 $this->connection,
                 $statement,
                 $this->messageFactory,
-                $sql,
                 $this->loadBatchSize,
                 $fromNumber,
                 $count,

--- a/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
@@ -27,13 +27,13 @@ final class MySqlAggregateStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE `$tableName` (
-    `no` INT(11) NOT NULL AUTO_INCREMENT,
+    `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
     `event_id` CHAR(36) COLLATE utf8_bin NOT NULL,
     `event_name` VARCHAR(100) COLLATE utf8_bin NOT NULL,
     `payload` JSON NOT NULL,
     `metadata` JSON NOT NULL,
     `created_at` DATETIME(6) NOT NULL,
-    `version` INT(11) GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$._aggregate_version')) STORED NOT NULL UNIQUE KEY,
+    `version` INT(11) UNSIGNED GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$._aggregate_version')) STORED NOT NULL UNIQUE KEY,
     PRIMARY KEY (`no`),
     UNIQUE KEY `ix_event_id` (`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;

--- a/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
@@ -26,7 +26,7 @@ final class MySqlSimpleStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE `$tableName` (
-    `no` INT(11) NOT NULL AUTO_INCREMENT,
+    `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
     `event_id` CHAR(36) COLLATE utf8_bin NOT NULL,
     `event_name` VARCHAR(100) COLLATE utf8_bin NOT NULL,
     `payload` JSON NOT NULL,

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -26,15 +26,15 @@ final class MySqlSingleStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE `$tableName` (
-    `no` INT(11) NOT NULL AUTO_INCREMENT,
+    `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
     `event_id` CHAR(36) COLLATE utf8_bin NOT NULL,
     `event_name` VARCHAR(100) COLLATE utf8_bin NOT NULL,
     `payload` JSON NOT NULL,
     `metadata` JSON NOT NULL,
     `created_at` DATETIME(6) NOT NULL,
-    `version` INT(11) GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$._aggregate_version')) STORED NOT NULL,
-    `aggregate_id` char(36) CHARACTER SET utf8 COLLATE utf8_bin GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_id'))) STORED NOT NULL,
-    `aggregate_type` varchar(150) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_type'))) STORED NOT NULL,
+    `version` INT(11) UNSIGNED GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$._aggregate_version')) STORED NOT NULL,
+    `aggregate_id` CHAR(36) CHARACTER SET utf8 COLLATE utf8_bin GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_id'))) STORED NOT NULL,
+    `aggregate_type` VARCHAR(150) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_type'))) STORED NOT NULL,
     PRIMARY KEY (`no`),
     UNIQUE KEY `ix_event_id` (`event_id`),
     UNIQUE KEY `ix_unique_event` (`version`, `aggregate_id`, `aggregate_type`)

--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -27,7 +27,7 @@ final class PostgresAggregateStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE $tableName (
-    no SERIAL,
+    no BIGSERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
     payload JSON NOT NULL,

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -26,7 +26,7 @@ final class PostgresSimpleStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE $tableName (
-    no SERIAL,
+    no BIGSERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
     payload JSON NOT NULL,

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -26,7 +26,7 @@ final class PostgresSingleStreamStrategy implements PersistenceStrategy
     {
         $statement = <<<EOT
 CREATE TABLE $tableName (
-    no SERIAL,
+    no BIGSERIAL,
     event_id CHAR(36) NOT NULL,
     event_name VARCHAR(100) NOT NULL,
     payload JSON NOT NULL,

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -252,7 +252,7 @@ EOT;
             $values[$parameter] = $value;
         }
 
-        $where[] = "no >= :fromNumber";
+        $where[] = 'no >= :fromNumber';
 
         $whereCondition = implode(' AND ', $where);
         $limit = min($count, $this->loadBatchSize);
@@ -327,7 +327,7 @@ EOT;
             $values[$parameter] = $value;
         }
 
-        $where[] = "no <= :fromNumber";
+        $where[] = 'no <= :fromNumber';
 
         $whereCondition = implode(' AND ', $where);
         $limit = min($count, $this->loadBatchSize);


### PR DESCRIPTION
Currently the queries in aggregate load methods from event stores builds queries and recreate this for batch requests.

This PR changes this behavior and implements prepared statements. The PdoStreamIterator has only to change the values for `fromNumber` and `limit` without have to know how to queries should be builded. 