### PR TITLE
Remove usage of MessageConverter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "prooph/common": "4.0.x-dev",
+        "prooph/common": "^4.0",
         "prooph/event-store": "7.0.x-dev"
     },
     "require-dev": {

--- a/src/Container/AbstractEventStoreFactory.php
+++ b/src/Container/AbstractEventStoreFactory.php
@@ -109,7 +109,6 @@ abstract class AbstractEventStoreFactory implements
 
         $eventStore = new $eventStoreClassName(
             $container->get($config['message_factory']),
-            $messageConverter = $container->get($config['message_converter']),
             $connection,
             $container->get($config['persistence_strategy']),
             $config['load_batch_size'],

--- a/src/Container/MySqlEventStoreFactory.php
+++ b/src/Container/MySqlEventStoreFactory.php
@@ -14,7 +14,6 @@ namespace Prooph\EventStore\Pdo\Container;
 
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\MySqlEventStore;
@@ -56,7 +55,6 @@ final class MySqlEventStoreFactory extends AbstractEventStoreFactory
             ],
             'load_batch_size' => 1000,
             'event_streams_table' => 'event_streams',
-            'message_converter' => NoOpMessageConverter::class,
             'message_factory' => FQCNMessageFactory::class,
             'wrap_action_event_emitter' => true,
             'metadata_enrichers' => [],

--- a/src/Container/PostgresEventStoreFactory.php
+++ b/src/Container/PostgresEventStoreFactory.php
@@ -14,7 +14,6 @@ namespace Prooph\EventStore\Pdo\Container;
 
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\PostgresEventStore;
@@ -60,7 +59,6 @@ final class PostgresEventStoreFactory extends AbstractEventStoreFactory
             ],
             'load_batch_size' => 1000,
             'event_streams_table' => 'event_streams',
-            'message_converter' => NoOpMessageConverter::class,
             'message_factory' => FQCNMessageFactory::class,
             'wrap_action_event_emitter' => true,
             'metadata_enrichers' => [],

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -15,7 +15,6 @@ namespace Prooph\EventStore\Pdo;
 use EmptyIterator;
 use Iterator;
 use PDO;
-use Prooph\Common\Messaging\MessageConverter;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\ConcurrencyException;
@@ -45,11 +44,6 @@ final class MySqlEventStore implements EventStore
      * @var MessageFactory
      */
     private $messageFactory;
-
-    /**
-     * @var MessageConverter
-     */
-    private $messageConverter;
 
     /**
      * @var PDO
@@ -102,7 +96,6 @@ final class MySqlEventStore implements EventStore
      */
     public function __construct(
         MessageFactory $messageFactory,
-        MessageConverter $messageConverter,
         PDO $connection,
         PersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
@@ -115,7 +108,6 @@ final class MySqlEventStore implements EventStore
         Assertion::min($loadBatchSize, 1);
 
         $this->messageFactory = $messageFactory;
-        $this->messageConverter = $messageConverter;
         $this->connection = $connection;
         $this->persistenceStrategy = $persistenceStrategy;
         $this->loadBatchSize = $loadBatchSize;

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -15,7 +15,6 @@ namespace Prooph\EventStore\Pdo;
 use EmptyIterator;
 use Iterator;
 use PDO;
-use Prooph\Common\Messaging\MessageConverter;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
@@ -47,11 +46,6 @@ final class PostgresEventStore implements TransactionalEventStore
      * @var MessageFactory
      */
     private $messageFactory;
-
-    /**
-     * @var MessageConverter
-     */
-    private $messageConverter;
 
     /**
      * @var PDO
@@ -99,7 +93,6 @@ final class PostgresEventStore implements TransactionalEventStore
      */
     public function __construct(
         MessageFactory $messageFactory,
-        MessageConverter $messageConverter,
         PDO $connection,
         PersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
@@ -112,7 +105,6 @@ final class PostgresEventStore implements TransactionalEventStore
         Assertion::min($loadBatchSize, 1);
 
         $this->messageFactory = $messageFactory;
-        $this->messageConverter = $messageConverter;
         $this->connection = $connection;
         $this->persistenceStrategy = $persistenceStrategy;
         $this->loadBatchSize = $loadBatchSize;

--- a/tests/Container/MySqlEventStoreFactoryTest.php
+++ b/tests/Container/MySqlEventStoreFactoryTest.php
@@ -15,7 +15,6 @@ namespace ProophTest\EventStore\Pdo\Container;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\Exception\ConfigurationException;
 use Prooph\EventStore\Metadata\MetadataEnricher;
@@ -49,7 +48,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $factory = new MySqlEventStoreFactory();
@@ -73,7 +71,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $eventStoreName = 'custom';
@@ -96,7 +93,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $eventStoreName = 'custom';
@@ -120,7 +116,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
@@ -152,7 +147,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
@@ -178,7 +172,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn($config);
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
@@ -207,7 +200,6 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn($config);
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');

--- a/tests/Container/PostgresEventStoreFactoryTest.php
+++ b/tests/Container/PostgresEventStoreFactoryTest.php
@@ -15,7 +15,6 @@ namespace ProophTest\EventStore\Pdo\Container;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\Exception\ConfigurationException;
 use Prooph\EventStore\Metadata\MetadataEnricher;
@@ -50,7 +49,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $factory = new PostgresEventStoreFactory();
@@ -74,7 +72,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $eventStoreName = 'custom';
@@ -97,7 +94,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $eventStoreName = 'custom';
@@ -121,7 +117,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
@@ -153,7 +148,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
 
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
@@ -179,7 +173,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn($config);
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
@@ -208,7 +201,6 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn($config);
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(NoOpMessageConverter::class)->willReturn(new NoOpMessageConverter())->shouldBeCalled();
         $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');

--- a/tests/MySqlEventStoreTest.php
+++ b/tests/MySqlEventStoreTest.php
@@ -14,7 +14,6 @@ namespace ProophTest\EventStore\Pdo;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
@@ -55,7 +54,6 @@ final class MySqlEventStoreTest extends AbstractPdoEventStoreTest
     {
         return new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $connection,
             new MySqlAggregateStreamStrategy()
         );
@@ -88,7 +86,6 @@ final class MySqlEventStoreTest extends AbstractPdoEventStoreTest
     {
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $this->connection,
             new MySqlSingleStreamStrategy(),
             5
@@ -159,7 +156,6 @@ final class MySqlEventStoreTest extends AbstractPdoEventStoreTest
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $this->connection,
             new MySqlSingleStreamStrategy()
         );

--- a/tests/PostgresEventStoreTest.php
+++ b/tests/PostgresEventStoreTest.php
@@ -14,7 +14,6 @@ namespace ProophTest\EventStore\Pdo;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamNotFound;
@@ -65,7 +64,6 @@ final class PostgresEventStoreTest extends AbstractPdoEventStoreTest
     {
         return new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $connection,
             new PostgresAggregateStreamStrategy()
         );
@@ -132,7 +130,6 @@ final class PostgresEventStoreTest extends AbstractPdoEventStoreTest
     {
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $this->connection,
             new PostgresSingleStreamStrategy(),
             5
@@ -169,7 +166,6 @@ final class PostgresEventStoreTest extends AbstractPdoEventStoreTest
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             $this->connection,
             new PostgresSingleStreamStrategy()
         );

--- a/tests/Projection/MySqlEventStoreProjectionTest.php
+++ b/tests/Projection/MySqlEventStoreProjectionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -34,7 +33,6 @@ class MySqlEventStoreProjectionTest extends PdoEventStoreProjectionTestCase
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new MySqlSimpleStreamStrategy()
         );

--- a/tests/Projection/MySqlEventStoreQueryTest.php
+++ b/tests/Projection/MySqlEventStoreQueryTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -34,7 +33,6 @@ class MySqlEventStoreQueryTest extends PdoEventStoreQueryTestCase
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new MySqlSimpleStreamStrategy()
         );

--- a/tests/Projection/MySqlEventStoreReadModelProjectionTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Projection\ReadModel;
@@ -35,7 +34,6 @@ class MySqlEventStoreReadModelProjectionTest extends PdoEventStoreReadModelProje
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new MySqlSimpleStreamStrategy()
         );

--- a/tests/Projection/PostgresEventStoreProjectionTest.php
+++ b/tests/Projection/PostgresEventStoreProjectionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -34,7 +33,6 @@ class PostgresEventStoreProjectionTest extends PdoEventStoreProjectionTestCase
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new PostgresSimpleStreamStrategy()
         );

--- a/tests/Projection/PostgresEventStoreQueryTest.php
+++ b/tests/Projection/PostgresEventStoreQueryTest.php
@@ -14,7 +14,6 @@ namespace ProophTest\EventStore\Pdo\Projection;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -35,7 +34,6 @@ class PostgresEventStoreQueryTest extends PdoEventStoreQueryTestCase
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new PostgresSimpleStreamStrategy()
         );

--- a/tests/Projection/PostgresEventStoreReadModelProjectionTest.php
+++ b/tests/Projection/PostgresEventStoreReadModelProjectionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
-use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Projection\ReadModel;
@@ -35,7 +34,6 @@ class PostgresEventStoreReadModelProjectionTest extends PdoEventStoreReadModelPr
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
-            new NoOpMessageConverter(),
             TestUtil::getConnection(),
             new PostgresSimpleStreamStrategy()
         );


### PR DESCRIPTION
After investigate the code I have found out the MessageConverter is not in use in booth event stores.
I am not sure if this should be used again or all usages could be removed.

But less is more, so I have removed it.