### PR TITLE
Catch and ignore duplicate projection error when creating it

### DIFF
--- a/src/Exception/ProjectionNotCreatedException.php
+++ b/src/Exception/ProjectionNotCreatedException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\Exception;
+
+class ProjectionNotCreatedException extends RuntimeException
+{
+    public static function with(string $projectionName): ProjectionNotCreatedException
+    {
+        return new self(sprintf('Projection "%s" was not created', $projectionName));
+    }
+}


### PR DESCRIPTION
This is an attempt to fix #76 

Unfortunately configuring the PDO connection from the beginning to throw exceptions on errors will result in almost all tests failing.
I think this should be addressed, but I believe it's outside of the scope of current issue.

@prolic any suggestions on how to make this better ?