### PR TITLE
fix for load/save within same transaction

### DIFF
--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -219,6 +219,17 @@ EOT;
         int $count = null,
         MetadataMatcher $metadataMatcher = null
     ): Iterator {
+        $tableName = $this->persistenceStrategy->generateTableName($streamName);
+
+        $query = "SELECT stream_name FROM $this->eventStreamsTable WHERE stream_name = ?";
+
+        $statement = $this->connection->prepare($query);
+        $statement->execute([$tableName]);
+
+        if ($statement->rowCount() === 0) {
+            throw StreamNotFound::with($streamName);
+        }
+
         [$where, $values] = $this->createWhereClause($metadataMatcher);
         $where[] = 'no >= :fromNumber';
 
@@ -229,8 +240,6 @@ EOT;
         } else {
             $limit = min($count, $this->loadBatchSize);
         }
-
-        $tableName = $this->persistenceStrategy->generateTableName($streamName);
 
         $query = <<<EOT
 SELECT * FROM $tableName


### PR DESCRIPTION
resolves https://github.com/prooph/pdo-event-store/issues/84

This is one possible solution (only needed for Postgres, because it's transactional)

Additional unit test would be added to event-store repo.