### PR TITLE
Remove port bindings from docker-compose

### DIFF
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -10,15 +10,11 @@ services:
 
   postgres:
     image: postgres:alpine
-    ports:
-      - 5432:5432
     environment:
       - POSTGRES_DB=event_store_tests
 
   mysql:
     image: mysql
-    ports:
-     - 3306:3306
     environment:
       - MYSQL_ROOT_PASSWORD=
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
Each container will have it's own IP that you can use to connect to MySQL/Postgres.

This commit allows for people running existing applications on these ports not to have to stop them as there is no reason to bind in the first place.

The `composer` container will have access to the other containers regardless.