### PR TITLE
Optionally trigger pcntl_signal_dispatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "prooph/event-store": "^7.1.3"
+        "prooph/event-store": "^7.2"
     },
     "require-dev": {
         "sandrokeil/interop-config": "^2.0.1",

--- a/src/Projection/MariaDbProjectionManager.php
+++ b/src/Projection/MariaDbProjectionManager.php
@@ -88,7 +88,7 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/src/Projection/MariaDbProjectionManager.php
+++ b/src/Projection/MariaDbProjectionManager.php
@@ -87,7 +87,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 
@@ -105,7 +106,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $this->projectionsTable,
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/src/Projection/MySqlProjectionManager.php
+++ b/src/Projection/MySqlProjectionManager.php
@@ -87,7 +87,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 
@@ -105,7 +106,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $this->projectionsTable,
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/src/Projection/MySqlProjectionManager.php
+++ b/src/Projection/MySqlProjectionManager.php
@@ -88,7 +88,7 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -170,7 +170,7 @@ final class PdoEventStoreProjector implements Projector
         $this->persistBlockSize = $persistBlockSize;
         $this->sleep = $sleep;
         $this->status = ProjectionStatus::IDLE();
-        $this->triggerPcntlSignalDispatch = extension_loaded('pcntl') && $triggerPcntlSignalDispatch;
+        $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch && extension_loaded('pcntl');
 
         while ($eventStore instanceof EventStoreDecorator) {
             $eventStore = $eventStore->getInnerEventStore();

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -38,6 +38,10 @@ use Prooph\EventStore\Util\ArrayCache;
 
 final class PdoEventStoreProjector implements Projector
 {
+    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
+
+    public const DEFAULT_PCNTL_DISPATCH = false;
+
     private const UNIQUE_VIOLATION_ERROR_CODES = [
         'pgsql' => '23505',
         'mysql' => '23000',

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -38,10 +38,6 @@ use Prooph\EventStore\Util\ArrayCache;
 
 final class PdoEventStoreProjector implements Projector
 {
-    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
-
-    public const DEFAULT_PCNTL_DISPATCH = false;
-
     private const UNIQUE_VIOLATION_ERROR_CODES = [
         'pgsql' => '23505',
         'mysql' => '23000',

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -35,9 +35,9 @@ use Prooph\EventStore\StreamName;
 
 final class PdoEventStoreReadModelProjector implements ReadModelProjector
 {
-    const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
+    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
 
-    const DEFAULT_PCNTL_DISPATCH = false;
+    public const DEFAULT_PCNTL_DISPATCH = false;
 
     /**
      * @var EventStore

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -147,6 +147,10 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         int $sleep,
         bool $triggerPcntlSignalDispatch = false
     ) {
+        if ($triggerPcntlSignalDispatch && ! extension_loaded('pcntl')) {
+            throw Exception\ExtensionNotLoadedException::withName('pcntl');
+        }
+
         $this->eventStore = $eventStore;
         $this->connection = $connection;
         $this->name = $name;
@@ -157,7 +161,7 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         $this->persistBlockSize = $persistBlockSize;
         $this->sleep = $sleep;
         $this->status = ProjectionStatus::IDLE();
-        $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch && extension_loaded('pcntl');
+        $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch;
 
         while ($eventStore instanceof EventStoreDecorator) {
             $eventStore = $eventStore->getInnerEventStore();
@@ -465,7 +469,9 @@ EOT;
 
                 $this->eventCounter = 0;
 
-                $this->triggerPcntlSignalDispatch();
+                if ($this->triggerPcntlSignalDispatch) {
+                    pcntl_signal_dispatch();
+                }
 
                 switch ($this->fetchRemoteStatus()) {
                     case ProjectionStatus::STOPPING():
@@ -815,12 +821,5 @@ EOT;
         }
 
         $this->streamPositions = array_merge($streamPositions, $this->streamPositions);
-    }
-
-    private function triggerPcntlSignalDispatch(): void
-    {
-        if ($this->triggerPcntlSignalDispatch) {
-            pcntl_signal_dispatch();
-        }
     }
 }

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -161,7 +161,7 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         $this->persistBlockSize = $persistBlockSize;
         $this->sleep = $sleep;
         $this->status = ProjectionStatus::IDLE();
-        $this->triggerPcntlSignalDispatch = extension_loaded('pcntl') && $triggerPcntlSignalDispatch;
+        $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch && extension_loaded('pcntl');
 
         while ($eventStore instanceof EventStoreDecorator) {
             $eventStore = $eventStore->getInnerEventStore();

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -35,10 +35,6 @@ use Prooph\EventStore\StreamName;
 
 final class PdoEventStoreReadModelProjector implements ReadModelProjector
 {
-    public const OPTION_PCNTL_DISPATCH = 'trigger_pcntl_dispatch';
-
-    public const DEFAULT_PCNTL_DISPATCH = false;
-
     /**
      * @var EventStore
      */

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -88,7 +88,7 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -87,7 +87,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::DEFAULT_LOCK_TIMEOUT_MS] ?? PdoEventStoreProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 
@@ -105,7 +106,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $this->projectionsTable,
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
-            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP
+            $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
         );
     }
 

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -174,14 +174,13 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if (!extension_loaded('pcntl')) {
+        if (! extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
+
+            return;
         }
 
-        $this->prepareEventStream('user-123');
-        $this->connection->exec('DROP TABLE projections;');
-
-        $command = 'php ' . realpath(__DIR__) . '/isolated-projection.php';
+        $command = 'exec php ' . realpath(__DIR__) . '/isolated-projection.php';
         $descriptorSpec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
@@ -193,9 +192,9 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
          */
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
         $processDetails = proc_get_status($projectionProcess);
-        sleep(2);
+        sleep(1);
         posix_kill($processDetails['pid'], SIGQUIT);
-        sleep(2);
+        sleep(1);
 
         $processDetails = proc_get_status($projectionProcess);
         $this->assertEquals(

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -168,4 +168,35 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
             10000
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_pcntl_signals_when_enabled(): void
+    {
+        $this->prepareEventStream('user-123');
+        $this->connection->exec('DROP TABLE projections;');
+
+        $command = 'php ' . realpath(__DIR__) . '/isolated-projection.php';
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        /**
+         * Created process inherits env variables from this process.
+         * Script returns with non-standard code SIGUSR1 from the handler and -1 else
+         */
+        $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
+        $processDetails = proc_get_status($projectionProcess);
+        sleep(2);
+        posix_kill($processDetails['pid'], SIGQUIT);
+        sleep(2);
+
+        $processDetails = proc_get_status($projectionProcess);
+        $this->assertEquals(
+            SIGUSR1,
+            $processDetails['exitcode']
+        );
+    }
 }

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -174,6 +174,10 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('The PCNTL extension is not available.');
+        }
+
         $this->prepareEventStream('user-123');
         $this->connection->exec('DROP TABLE projections;');
 

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -191,4 +191,35 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
             10
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_pcntl_signals_when_enabled(): void
+    {
+        $this->prepareEventStream('user-123');
+        $this->connection->exec('DROP TABLE projections;');
+
+        $command = 'php ' . realpath(__DIR__) . '/isolated-read-model-projection.php';
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        /**
+         * Created process inherits env variables from this process.
+         * Script returns with non-standard code SIGUSR1 from the handler and -1 else
+         */
+        $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
+        $processDetails = proc_get_status($projectionProcess);
+        sleep(2);
+        posix_kill($processDetails['pid'], SIGQUIT);
+        sleep(2);
+
+        $processDetails = proc_get_status($projectionProcess);
+        $this->assertEquals(
+            SIGUSR1,
+            $processDetails['exitcode']
+        );
+    }
 }

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -197,6 +197,10 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('The PCNTL extension is not available.');
+        }
+
         $this->prepareEventStream('user-123');
         $this->connection->exec('DROP TABLE projections;');
 

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -197,14 +197,13 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
      */
     public function it_dispatches_pcntl_signals_when_enabled(): void
     {
-        if (!extension_loaded('pcntl')) {
+        if (! extension_loaded('pcntl')) {
             $this->markTestSkipped('The PCNTL extension is not available.');
+
+            return;
         }
 
-        $this->prepareEventStream('user-123');
-        $this->connection->exec('DROP TABLE projections;');
-
-        $command = 'php ' . realpath(__DIR__) . '/isolated-read-model-projection.php';
+        $command = 'exec php ' . realpath(__DIR__) . '/isolated-read-model-projection.php';
         $descriptorSpec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
@@ -216,9 +215,9 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
          */
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
         $processDetails = proc_get_status($projectionProcess);
-        sleep(2);
+        sleep(1);
         posix_kill($processDetails['pid'], SIGQUIT);
-        sleep(2);
+        sleep(1);
 
         $processDetails = proc_get_status($projectionProcess);
         $this->assertEquals(

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
@@ -26,7 +28,7 @@ $projectionManager = new MySqlProjectionManager(
 $projection = $projectionManager->createProjection(
     'test_projection',
     [
-        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true
+        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -1,0 +1,43 @@
+<?php
+
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Pdo\MySqlEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
+use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
+use Prooph\EventStore\Pdo\Projection\PdoEventStoreProjector;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Pdo\TestUtil;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$connection = TestUtil::getConnection();
+TestUtil::initDefaultDatabaseTables($connection);
+
+$eventStore = new MySqlEventStore(
+    new FQCNMessageFactory(),
+    $connection,
+    new MySqlSimpleStreamStrategy()
+);
+
+$projectionManager = new MySqlProjectionManager(
+    $eventStore,
+    $connection
+);
+$projection = $projectionManager->createProjection(
+    'test_projection',
+    [
+        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true
+    ]
+);
+pcntl_signal(SIGQUIT, function () use ($projection) {
+    $projection->stop();
+    exit(SIGUSR1);
+});
+$projection
+    ->fromStream('user-123')
+    ->when([
+        UserCreated::class => function (array $state, UserCreated $event): array {
+            return $state;
+        },
+    ])
+    ->run();

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -1,16 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use Prooph\EventStore\Pdo\Projection\PdoEventStoreProjector;
+use Prooph\EventStore\Projection\ReadModel;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Pdo\TestUtil;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$readModel = new class() implements \Prooph\EventStore\Projection\ReadModel {
+$readModel = new class() implements ReadModel {
     public function init(): void
     {
     }
@@ -54,7 +57,7 @@ $projection = $projectionManager->createReadModelProjection(
     'test_projection',
     $readModel,
     [
-        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true
+        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -1,0 +1,71 @@
+<?php
+
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Pdo\MySqlEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
+use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
+use Prooph\EventStore\Pdo\Projection\PdoEventStoreProjector;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Pdo\TestUtil;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$readModel = new class() implements \Prooph\EventStore\Projection\ReadModel {
+    public function init(): void
+    {
+    }
+
+    public function isInitialized(): bool
+    {
+        return true;
+    }
+
+    public function reset(): void
+    {
+    }
+
+    public function delete(): void
+    {
+    }
+
+    public function stack(string $operation, ...$args): void
+    {
+    }
+
+    public function persist(): void
+    {
+    }
+};
+
+$connection = TestUtil::getConnection();
+TestUtil::initDefaultDatabaseTables($connection);
+
+$eventStore = new MySqlEventStore(
+    new FQCNMessageFactory(),
+    $connection,
+    new MySqlSimpleStreamStrategy()
+);
+
+$projectionManager = new MySqlProjectionManager(
+    $eventStore,
+    $connection
+);
+$projection = $projectionManager->createReadModelProjection(
+    'test_projection',
+    $readModel,
+    [
+        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true
+    ]
+);
+pcntl_signal(SIGQUIT, function () use ($projection) {
+    $projection->stop();
+    exit(SIGUSR1);
+});
+$projection
+    ->fromStream('user-123')
+    ->when([
+        UserCreated::class => function (array $state, UserCreated $event): array {
+            return $state;
+        },
+    ])
+    ->run();

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 


### PR DESCRIPTION
Currently there is no way to gracefully shut down a running projection when any OS signals are received. Setting the projection is `stopping` state via a custom CLI script is not always an option (e.g. when projections and others are managed by supervisord). 

I think how the different signals should be handled should be left to the programmer, I have included a short example for reference below. In any case, to support this feature the projection loop at least needs to trigger the signal dispatch function.

Some remarks on my approach:
- `declare(ticks=1)` is not required anymore to my knowledge, it got replaced by `pcntl_signal_dispatch`
- I made this argument optional, defaulting to `false` to remain fully backwards compatible
- The location of the `triggerPcntlSignalDispatch` call within the loop has quite a few implications. It might even make sense to trigger this before `usleep`. 

```
        $pcntlCallback = function () use ($name) {
            echo "Attempting graceful shutdown of projection " . $name . PHP_EOL;
            $this->currentProjection->stop();
        };
        pcntl_signal(SIGTERM, $pcntlCallback);
        pcntl_signal(SIGINT, $pcntlCallback);
        pcntl_signal(SIGQUIT, $pcntlCallback);

      $this->currentProjection->start();
```