### PR TITLE
fix lock until string

### DIFF
--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -725,7 +725,8 @@ EOT;
     {
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         $nowString = $now->format('Y-m-d\TH:i:s.u');
-        $lockUntilString = $now->modify('+' . (string) $this->lockTimeoutMs . ' ms')->format('Y-m-d\TH:i:s.u');
+
+        $lockUntilString = $this->createLockUntilString($now);
 
         $sql = <<<EOT
 UPDATE $this->projectionsTable SET locked_until = ?, status = ? WHERE name = ? AND (locked_until IS NULL OR locked_until < ?);
@@ -758,7 +759,8 @@ EOT;
     {
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         $nowString = $now->format('Y-m-d\TH:i:s.u');
-        $lockUntilString = $now->modify('+' . (string) $this->lockTimeoutMs . ' ms')->format('Y-m-d\TH:i:s.u');
+
+        $lockUntilString = $this->createLockUntilString($now);
 
         $sql = <<<EOT
 UPDATE $this->projectionsTable SET locked_until = ? WHERE name = ?;
@@ -808,7 +810,8 @@ EOT;
     private function persist(): void
     {
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-        $lockUntilString = $now->modify('+' . (string) $this->lockTimeoutMs . ' ms')->format('Y-m-d\TH:i:s.u');
+
+        $lockUntilString = $this->createLockUntilString($now);
 
         $sql = <<<EOT
 UPDATE $this->projectionsTable SET position = ?, state = ?, locked_until = ? 
@@ -903,5 +906,20 @@ EOT;
         }
 
         $this->streamPositions = array_merge($streamPositions, $this->streamPositions);
+    }
+
+    private function createLockUntilString(DateTimeImmutable $from): string
+    {
+        $micros = (string) ((int) $from->format('u') + ($this->lockTimeoutMs * 1000));
+
+        $secs = substr($micros, 0, -6);
+
+        if ('' === $secs) {
+            $secs = 0;
+        }
+
+        $resultMicros = substr($micros, -6);
+
+        return $from->modify('+' . $secs .' seconds')->format('Y-m-d\TH:i:s') . '.' . $resultMicros;
     }
 }

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -758,7 +758,6 @@ EOT;
     private function updateLock(): void
     {
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-        $nowString = $now->format('Y-m-d\TH:i:s.u');
 
         $lockUntilString = $this->createLockUntilString($now);
 


### PR DESCRIPTION
resolves https://github.com/prooph/pdo-event-store/issues/98#issuecomment-314066675

The problem comes from

`$dateTime->modify('+200 ms');` is invalid, you can only add seconds, minutes, hours, and so on, but no micro- or milliseconds. This this needed to be worked around.