### PR TITLE
PdoEventStore Interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,11 @@
         "cs-fix": "php-cs-fixer fix -v --diff",
         "test-postgres": "DB_HOST=postgres vendor/bin/phpunit -c phpunit.xml.postgres",
         "test-mariadb": "DB_HOST=mariadb vendor/bin/phpunit -c phpunit.xml.mariadb",
-        "test-mysql": "DB_HOST=mysql vendor/bin/phpunit -c phpunit.xml.mysql"
+        "test-mysql": "DB_HOST=mysql vendor/bin/phpunit -c phpunit.xml.mysql",
+        "test-all": [
+            "@test-postgres",
+            "@test-mariadb",
+            "@test-mysql"
+        ]
     }
 }

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -8,6 +8,8 @@ services:
       - postgres:postgres
       - mariadb:mariadb
       - mysql:mysql
+    environment:
+      - COMPOSER_ALLOW_SUPERUSER=1
 
   postgres:
     image: postgres:alpine

--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -17,7 +17,6 @@ use Iterator;
 use PDO;
 use PDOException;
 use Prooph\Common\Messaging\MessageFactory;
-use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
@@ -30,7 +29,7 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\Util\Assertion;
 
-final class MariaDbEventStore implements EventStore
+final class MariaDbEventStore implements PdoEventStore
 {
     /**
      * @var MessageFactory

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -17,7 +17,6 @@ use Iterator;
 use PDO;
 use PDOException;
 use Prooph\Common\Messaging\MessageFactory;
-use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
@@ -30,7 +29,7 @@ use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use Prooph\EventStore\Util\Assertion;
 
-final class MySqlEventStore implements EventStore
+final class MySqlEventStore implements PdoEventStore
 {
     /**
      * @var MessageFactory

--- a/src/PdoEventStore.php
+++ b/src/PdoEventStore.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo;
+
+use Prooph\EventStore\EventStore;
+
+interface PdoEventStore extends EventStore
+{
+}

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -32,7 +32,7 @@ use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalEventStore;
 use Prooph\EventStore\Util\Assertion;
 
-final class PostgresEventStore implements TransactionalEventStore
+final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
 {
     /**
      * @var MessageFactory

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -26,9 +26,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\ProjectionNotCreatedException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\PdoEventStore;
 use Prooph\EventStore\Projection\ProjectionStatus;
 use Prooph\EventStore\Projection\Projector;
 use Prooph\EventStore\Stream;
@@ -179,10 +177,7 @@ final class PdoEventStoreProjector implements Projector
             $eventStore = $eventStore->getInnerEventStore();
         }
 
-        if (! $eventStore instanceof MariaDbEventStore
-            && ! $eventStore instanceof MySqlEventStore
-            && ! $eventStore instanceof PostgresEventStore
-        ) {
+        if (! $eventStore instanceof PdoEventStore) {
             throw new Exception\InvalidArgumentException('Unknown event store instance given');
         }
     }

--- a/src/Projection/PdoEventStoreQuery.php
+++ b/src/Projection/PdoEventStoreQuery.php
@@ -21,9 +21,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\PdoEventStore;
 use Prooph\EventStore\Projection\Query;
 use Prooph\EventStore\StreamName;
 
@@ -94,10 +92,7 @@ final class PdoEventStoreQuery implements Query
             $eventStore = $eventStore->getInnerEventStore();
         }
 
-        if (! $eventStore instanceof MariaDbEventStore
-            && ! $eventStore instanceof MySqlEventStore
-            && ! $eventStore instanceof PostgresEventStore
-        ) {
+        if (! $eventStore instanceof PdoEventStore) {
             throw new Exception\InvalidArgumentException('Unknown event store instance given');
         }
     }

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -23,9 +23,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\PdoEventStore;
 use Prooph\EventStore\Projection\ProjectionStatus;
 use Prooph\EventStore\Projection\ReadModel;
 use Prooph\EventStore\Projection\ReadModelProjector;
@@ -165,10 +163,7 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
             $eventStore = $eventStore->getInnerEventStore();
         }
 
-        if (! $eventStore instanceof MariaDbEventStore
-            && ! $eventStore instanceof MySqlEventStore
-            && ! $eventStore instanceof PostgresEventStore
-        ) {
+        if (! $eventStore instanceof PdoEventStore) {
             throw new Exception\InvalidArgumentException('Unknown event store instance given');
         }
     }

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -128,6 +128,7 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
@@ -152,6 +153,7 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $connection = $this->prophesize(PDO::class);

--- a/tests/Projection/PdoEventStoreQueryTest.php
+++ b/tests/Projection/PdoEventStoreQueryTest.php
@@ -97,6 +97,7 @@ abstract class PdoEventStoreQueryTest extends AbstractEventStoreQueryTest
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
@@ -116,6 +117,7 @@ abstract class PdoEventStoreQueryTest extends AbstractEventStoreQueryTest
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $connection = $this->prophesize(PDO::class);

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -150,6 +150,7 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
     public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
@@ -174,6 +175,7 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
     public function it_throws_exception_when_unknown_event_store_instance_passed(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
 
         $eventStore = $this->prophesize(EventStore::class);
         $connection = $this->prophesize(PDO::class);


### PR DESCRIPTION
This PR provides a PdoEventStore interface (without any additional method for now).

Goal is to remove this instance chaining test expression, so that it would not be necessary to change that expression in future implementations.
Also it would be possible to use own pro event store implementations by users.

Another Proposal (not implemented yet):
The PdoEventStore interface could provide a `getConnection` method to ensure the same connection is used for projection. (Not sure if that would be intentional)