### PR TITLE
Drop stream table only if it exists

### DIFF
--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -179,7 +179,7 @@ EOT;
             $tableName = $this->persistenceStrategy->generateTableName($streamName);
             $this->createSchemaFor($tableName);
         } catch (RuntimeException $exception) {
-            $this->connection->exec("DROP TABLE $tableName;");
+            $this->connection->exec("DROP TABLE IF EXISTS $tableName;");
             $this->removeStreamFromStreamsTable($streamName);
 
             throw $exception;

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -179,7 +179,7 @@ EOT;
             $tableName = $this->persistenceStrategy->generateTableName($streamName);
             $this->createSchemaFor($tableName);
         } catch (RuntimeException $exception) {
-            $this->connection->exec("DROP TABLE $tableName;");
+            $this->connection->exec("DROP TABLE IF EXISTS $tableName;");
             $this->removeStreamFromStreamsTable($streamName);
 
             throw $exception;

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -177,7 +177,7 @@ EOT;
             $tableName = $this->persistenceStrategy->generateTableName($streamName);
             $this->createSchemaFor($tableName);
         } catch (RuntimeException $exception) {
-            $this->connection->exec("DROP TABLE $tableName;");
+            $this->connection->exec("DROP TABLE IF EXISTS $tableName;");
             $this->removeStreamFromStreamsTable($streamName);
 
             throw $exception;

--- a/tests/MySqlEventStoreTest.php
+++ b/tests/MySqlEventStoreTest.php
@@ -20,6 +20,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlAggregateStreamStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSingleStreamStrategy;
 use Prooph\EventStore\Stream;
@@ -172,5 +173,29 @@ final class MySqlEventStoreTest extends AbstractPdoEventStoreTest
         );
 
         $eventStore->appendTo(new StreamName('Prooph\Model\User'), new ArrayIterator([$streamEvent]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_stream_if_stream_table_hasnt_been_created(): void
+    {
+        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy->method('createSchema')->willReturn(["SIGNAL SQLSTATE '45000';"]);
+        $strategy->method('generateTableName')->willReturn('_non_existing_table');
+
+        $eventStore = new MysqlEventStore(
+            new FQCNMessageFactory(),
+            $this->connection,
+            $strategy
+        );
+        $stream = new Stream(new StreamName('Prooph\Model\User'), new ArrayIterator());
+
+        try {
+            $eventStore->create($stream);
+        } catch (RuntimeException $e) {
+        }
+
+        $this->assertFalse($eventStore->hasStream($stream->streamName()));
     }
 }


### PR DESCRIPTION
If an error occurs while creating a stream table, the stream table dropping produces a new error because the table doesn't exists. In this case `removeStreamFromStreamsTable` is not called and a corresponding record from the streams table is not deleted.