### PR TITLE
Catch Throwable in transactional()

### DIFF
--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -428,7 +428,7 @@ EOT;
         try {
             $result = $callable($this);
             $this->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->rollback();
             throw $e;
         }


### PR DESCRIPTION
`transactional()` should rollback on any \Throwable, not just exceptions.