### PR TITLE
Fix silently ignored errors in PostgresEventStore

### DIFF
--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -219,6 +219,10 @@ EOT;
         if (in_array($statement->errorCode(), ['23000', '23505'], true)) {
             throw new ConcurrencyException();
         }
+        
+        if ($statement->errorCode() !== '00000') {
+            throw RuntimeException::fromStatementErrorInfo($statement->errorInfo());
+        }
     }
 
     public function load(

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -219,7 +219,7 @@ EOT;
         if (in_array($statement->errorCode(), ['23000', '23505'], true)) {
             throw new ConcurrencyException();
         }
-        
+
         if ($statement->errorCode() !== '00000') {
             throw RuntimeException::fromStatementErrorInfo($statement->errorInfo());
         }


### PR DESCRIPTION
This hotfix should be merged an released ASAP. Better fix will be later in https://github.com/prooph/pdo-event-store/pull/117.