### PR TITLE
Use JSON_UNQUOTE instead of unquoting operator

### DIFF
--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -699,7 +699,7 @@ SQL;
                     continue;
                 }
 
-                $where[] = "metadata->>\"$.$field\" $operatorString $parameterString $operatorStringEnd";
+                $where[] = "JSON_UNQUOTE(metadata->\"$.$field\") $operatorString $parameterString $operatorStringEnd";
             } else {
                 if (is_bool($value)) {
                     $where[] = "$field $operatorString " . var_export($value, true) . ' ' . $operatorStringEnd;


### PR DESCRIPTION
Unquoting extraction operator ->> was introduced in 5.7.13 and min. req. version (in README) is 5.7.9.

So either min. required version needs to get bumped to 5.7.13 or we use the JSON_UNQUOTE function.