### PR TITLE
Event name propagation

### DIFF
--- a/scripts/postgres/01_event_streams_table.sql
+++ b/scripts/postgres/01_event_streams_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE event_streams (
+CREATE TABLE e_stream (
   no BIGSERIAL,
   real_stream_name VARCHAR(150) NOT NULL,
   stream_name CHAR(41) NOT NULL,
@@ -7,4 +7,4 @@ CREATE TABLE event_streams (
   PRIMARY KEY (no),
   UNIQUE (stream_name)
 );
-CREATE INDEX on event_streams (category);
+CREATE INDEX on e_stream (category);

--- a/tests/AbstractPdoEventStoreTest.php
+++ b/tests/AbstractPdoEventStoreTest.php
@@ -75,27 +75,7 @@ abstract class AbstractPdoEventStoreTest extends AbstractEventStoreTest
 
     protected function tearDown(): void
     {
-        $vendor = TestUtil::getDatabaseVendor();
-        switch ($vendor) {
-            case 'postgres':
-                $statement = $this->connection->prepare('SELECT table_name FROM information_schema.tables WHERE table_schema = \'public\';');
-                break;
-            default:
-                $statement = $this->connection->prepare('SHOW TABLES');
-        }
-
-        $statement->execute();
-        $tables = $statement->fetchAll(PDO::FETCH_COLUMN);
-
-        foreach ($tables as $table) {
-            switch ($vendor) {
-                case 'postgres':
-                    $this->connection->exec(sprintf('DROP TABLE "%s";', $table));
-                    break;
-                default:
-                    $this->connection->exec(sprintf('DROP TABLE `%s`;', $table));
-            }
-        }
+        TestUtil::tearDownDatabase();
     }
 
     /**

--- a/tests/Projection/MariaDbProjectionManagerTest.php
+++ b/tests/Projection/MariaDbProjectionManagerTest.php
@@ -63,8 +63,7 @@ class MariaDbProjectionManagerTest extends AbstractProjectionManagerTest
 
     protected function tearDown(): void
     {
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
+        TestUtil::tearDownDatabase();
     }
 
     /**

--- a/tests/Projection/MySqlProjectionManagerTest.php
+++ b/tests/Projection/MySqlProjectionManagerTest.php
@@ -63,8 +63,7 @@ class MySqlProjectionManagerTest extends AbstractProjectionManagerTest
 
     protected function tearDown(): void
     {
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
+        TestUtil::tearDownDatabase();
     }
 
     /**

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -22,6 +22,7 @@ use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Projection\Projector;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractEventStoreProjectorTest;
 
 abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTest
@@ -43,17 +44,7 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
 
     protected function tearDown(): void
     {
-        // these tables are used in every test case
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-123'));
-        // these tables are used only in some test cases
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-234'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('$iternal-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-456'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('foo'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('test_projection'));
+        TestUtil::tearDownDatabase();
     }
 
     /**

--- a/tests/Projection/PdoEventStoreQueryTest.php
+++ b/tests/Projection/PdoEventStoreQueryTest.php
@@ -21,6 +21,7 @@ use Prooph\EventStore\Pdo\Projection\PdoEventStoreQuery;
 use Prooph\EventStore\Projection\ProjectionManager;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractEventStoreQueryTest;
 
 abstract class PdoEventStoreQueryTest extends AbstractEventStoreQueryTest
@@ -42,17 +43,7 @@ abstract class PdoEventStoreQueryTest extends AbstractEventStoreQueryTest
 
     protected function tearDown(): void
     {
-        // these tables are used in every test case
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-123'));
-        // these tables are used only in some test cases
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-234'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('$iternal-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-456'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('foo'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('test_projection'));
+        TestUtil::tearDownDatabase();
     }
 
     /**

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -26,6 +26,7 @@ use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\ReadModelMock;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Mock\UsernameChanged;
+use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractEventStoreReadModelProjectorTest;
 
 abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreReadModelProjectorTest
@@ -47,17 +48,7 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
 
     protected function tearDown(): void
     {
-        // these tables are used in every test case
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-123'));
-        // these tables are used only in some test cases
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('user-234'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('$iternal-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-345'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('guest-456'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('foo'));
-        $this->connection->exec('DROP TABLE IF EXISTS _' . sha1('test_projection'));
+        TestUtil::tearDownDatabase();
     }
 
     protected function prepareEventStream(string $name): void

--- a/tests/Projection/PostgresProjectionManagerTest.php
+++ b/tests/Projection/PostgresProjectionManagerTest.php
@@ -59,7 +59,7 @@ class PostgresProjectionManagerTest extends AbstractProjectionManagerTest
             $this->connection,
             new PostgresAggregateStreamStrategy()
         );
-        $this->projectionManager = new PostgresProjectionManager($this->eventStore, $this->connection);
+        $this->projectionManager = new PostgresProjectionManager($this->eventStore, $this->connection, 'e_stream');
     }
 
     protected function tearDown(): void

--- a/tests/Projection/PostgresProjectionManagerTest.php
+++ b/tests/Projection/PostgresProjectionManagerTest.php
@@ -64,8 +64,7 @@ class PostgresProjectionManagerTest extends AbstractProjectionManagerTest
 
     protected function tearDown(): void
     {
-        $this->connection->exec('DROP TABLE IF EXISTS event_streams;');
-        $this->connection->exec('DROP TABLE IF EXISTS projections;');
+        TestUtil::tearDownDatabase();
     }
 
     /**


### PR DESCRIPTION
I think I have hit a bug that should be fixed before I can continue with quoting of table names in projections.

this PR only demonstrates it, checkout and run with;
```
docker-compose -f docker-compose-tests.yml run composer run-script test-postgres --timeout 0 tests/Projection/PostgresEventStoreReadModelProjectorTest.php; docker stop proophpdoeventstore_postgres_1 && docker rm proophpdoeventstore_postgres_1
```

something is still trying to insert into `event_streams`