### PR TITLE
Remove useless code

### DIFF
--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -233,13 +233,6 @@ EOT;
     ): Iterator {
         $tableName = $this->persistenceStrategy->generateTableName($streamName);
 
-        $query = "SELECT stream_name FROM \"$this->eventStreamsTable\" WHERE stream_name = ?";
-        $statement = $this->connection->prepare($query);
-        $statement->execute([$tableName]);
-
-        if ($statement->rowCount() === 0) {
-            throw StreamNotFound::with($streamName);
-        }
         [$where, $values] = $this->createWhereClause($metadataMatcher);
         $where[] = 'no >= :fromNumber';
 


### PR DESCRIPTION
While debugging https://github.com/proophsoftware/es-emergency-call/issues/5 I also notices there are 2 SQL queries executed every time you call `EventStore::load()`. The first query checks if the stream exists in the database and only second query selects the events.

I believe the first command is useless. In case the table doesn't exist the second command will fail and it will result in the same exception (`StreamNotFound`). The only difference is that there is no check if the stream is registered in the event streams table which doesn't seem too important.

This doesn't make any huge difference for me as my performance issue was far more serious but still halving the amount of SQL queries is nice.