### PR TITLE
Add projection option:  update lock threshold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "prooph/event-store": "^7.3.1"
+        "prooph/event-store": "dev-master"
     },
     "require-dev": {
         "sandrokeil/interop-config": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "prooph/event-store": "dev-master"
+        "prooph/event-store": "^7.3.4"
     },
     "require-dev": {
         "sandrokeil/interop-config": "^2.0.1",

--- a/src/Projection/MariaDbProjectionManager.php
+++ b/src/Projection/MariaDbProjectionManager.php
@@ -88,7 +88,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 
@@ -107,7 +108,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/src/Projection/MariaDbProjectionManager.php
+++ b/src/Projection/MariaDbProjectionManager.php
@@ -109,7 +109,7 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/src/Projection/MySqlProjectionManager.php
+++ b/src/Projection/MySqlProjectionManager.php
@@ -88,7 +88,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 
@@ -107,7 +108,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/src/Projection/MySqlProjectionManager.php
+++ b/src/Projection/MySqlProjectionManager.php
@@ -109,7 +109,7 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -955,9 +955,14 @@ EOT;
             return true;
         }
 
-        $threshold = ((int) $this->lastLockUpdate->format('u') + ($this->updateLockThreshold * 1000));
+        //Create a 0 interval
+        $updateLockThreshold = new \DateInterval('PT0S');
+        //and manually add split seconds
+        $updateLockThreshold->f = $this->updateLockThreshold / 1000;
 
-        return $threshold <= (int) $now->format('u');
+        $threshold = $this->lastLockUpdate->add($updateLockThreshold);
+
+        return $threshold <= $now;
     }
 
     private function quoteTableName(string $tableName): string

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -136,6 +136,11 @@ final class PdoEventStoreProjector implements Projector
     private $triggerPcntlSignalDispatch;
 
     /**
+     * @var int
+     */
+    private $updateLockThreshold;
+
+    /**
      * @var array|null
      */
     private $query;
@@ -150,6 +155,11 @@ final class PdoEventStoreProjector implements Projector
      */
     private $vendor;
 
+    /**
+     * @var DateTimeImmutable
+     */
+    private $lastLockUpdate;
+
     public function __construct(
         EventStore $eventStore,
         PDO $connection,
@@ -160,7 +170,8 @@ final class PdoEventStoreProjector implements Projector
         int $cacheSize,
         int $persistBlockSize,
         int $sleep,
-        bool $triggerPcntlSignalDispatch = false
+        bool $triggerPcntlSignalDispatch = false,
+        int $updateLockThreshold = 0
     ) {
         if ($triggerPcntlSignalDispatch && ! extension_loaded('pcntl')) {
             throw Exception\ExtensionNotLoadedException::withName('pcntl');
@@ -177,6 +188,7 @@ final class PdoEventStoreProjector implements Projector
         $this->sleep = $sleep;
         $this->status = ProjectionStatus::IDLE();
         $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch;
+        $this->updateLockThreshold = $updateLockThreshold;
         $this->vendor = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         while ($eventStore instanceof EventStoreDecorator) {
@@ -760,11 +772,16 @@ EOT;
         }
 
         $this->status = ProjectionStatus::RUNNING();
+        $this->lastLockUpdate = $now;
     }
 
     private function updateLock(): void
     {
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        if (! $this->shouldUpdateLock($now)) {
+            return;
+        }
 
         $lockUntilString = $this->createLockUntilString($now);
 
@@ -928,6 +945,17 @@ EOT;
         $resultMicros = substr($micros, -6);
 
         return $from->modify('+' . $secs .' seconds')->format('Y-m-d\TH:i:s') . '.' . $resultMicros;
+    }
+
+    private function shouldUpdateLock(DateTimeImmutable $now): bool
+    {
+        if ($this->lastLockUpdate === null || $this->updateLockThreshold === 0) {
+            return true;
+        }
+
+        $threshold = ((int) $this->lastLockUpdate->format('u') + ($this->updateLockThreshold * 1000));
+
+        return $threshold <= (int) $now->format('u');
     }
 
     private function quoteTableName(string $tableName): string

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -815,6 +815,8 @@ EOT;
 
             throw new Exception\RuntimeException('Unknown error occurred');
         }
+
+        $this->lastLockUpdate = $now;
     }
 
     private function releaseLock(): void

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -127,6 +127,11 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
     private $triggerPcntlSignalDispatch;
 
     /**
+     * @var int
+     */
+    private $updateLockThreshold;
+
+    /**
      * @var array|null
      */
     private $query;
@@ -146,7 +151,8 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         int $lockTimeoutMs,
         int $persistBlockSize,
         int $sleep,
-        bool $triggerPcntlSignalDispatch = false
+        bool $triggerPcntlSignalDispatch = false,
+        int $updateLockThreshold = 0
     ) {
         if ($triggerPcntlSignalDispatch && ! extension_loaded('pcntl')) {
             throw Exception\ExtensionNotLoadedException::withName('pcntl');
@@ -163,6 +169,7 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         $this->sleep = $sleep;
         $this->status = ProjectionStatus::IDLE();
         $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch;
+        $this->updateLockThreshold = $updateLockThreshold;
         $this->vendor = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
         while ($eventStore instanceof EventStoreDecorator) {
             $eventStore = $eventStore->getInnerEventStore();

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -902,9 +902,14 @@ EOT;
             return true;
         }
 
-        $threshold = ((int) $this->lastLockUpdate->format('u') + ($this->updateLockThreshold * 1000));
+        //Create a 0 interval
+        $updateLockThreshold = new \DateInterval('PT0S');
+        //and manually add split seconds
+        $updateLockThreshold->f = $this->updateLockThreshold / 1000;
 
-        return $threshold <= (int) $now->format('u');
+        $threshold = $this->lastLockUpdate->add($updateLockThreshold);
+
+        return $threshold <= $now;
     }
 
     private function quoteTableName(string $tableName): string

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -109,7 +109,7 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -88,7 +88,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_CACHE_SIZE] ?? PdoEventStoreProjector::DEFAULT_CACHE_SIZE,
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 
@@ -107,7 +108,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS] ?? PdoEventStoreReadModelProjector::DEFAULT_LOCK_TIMEOUT_MS,
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
-            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH
+            $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
         );
     }
 

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -222,20 +222,21 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
          */
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
 
-        sleep(2);
+        sleep(1);
 
         $lockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 
         $this->assertNotNull($lockedUntil);
 
-        //Update lock threshold is set to 500 ms
-        usleep(200000);
+        //Update lock threshold is set to 2000 ms
+        usleep(500000);
 
         $notUpdatedLockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 
         $this->assertEquals($lockedUntil, $notUpdatedLockedUntil);
 
-        usleep(500000);
+        //Now we should definitely see an updated lock
+        sleep(2);
 
         $processDetails = proc_get_status($projectionProcess);
 

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -222,7 +222,7 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
          */
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
 
-        usleep(100000);
+        sleep(2);
 
         $lockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -195,4 +195,61 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
             $processDetails['exitcode']
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_respects_update_lock_threshold(): void
+    {
+        if (! extension_loaded('pcntl')) {
+            $this->markTestSkipped('The PCNTL extension is not available.');
+
+            return;
+        }
+
+        $this->prepareEventStream('user-123');
+
+        $command = 'exec php ' . realpath(__DIR__) . '/isolated-projection.php';
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        /**
+         * Created process inherits env variables from this process.
+         * Script returns with non-standard code SIGUSR1 from the handler and -1 else
+         */
+        $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
+
+        usleep(100000);
+
+        $lockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
+
+        $this->assertNotNull($lockedUntil);
+
+        //Update lock threshold is set to 500 ms
+        usleep(200000);
+
+        $notUpdatedLockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
+
+        $this->assertEquals($lockedUntil, $notUpdatedLockedUntil);
+
+        usleep(500000);
+
+        $processDetails = proc_get_status($projectionProcess);
+
+        $updatedLockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
+
+        $this->assertGreaterThan($lockedUntil, $updatedLockedUntil);
+
+        posix_kill($processDetails['pid'], SIGQUIT);
+
+        sleep(1);
+
+        $processDetails = proc_get_status($projectionProcess);
+        $this->assertFalse(
+            $processDetails['running']
+        );
+    }
 }

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -252,4 +252,98 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
             $processDetails['running']
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_should_update_lock_if_projection_is_not_locked()
+    {
+        $projectorRef = new \ReflectionClass(PdoEventStoreProjector::class);
+
+        $shouldUpdateLock = new \ReflectionMethod(PdoEventStoreProjector::class, 'shouldUpdateLock');
+
+        $shouldUpdateLock->setAccessible(true);
+
+        $projector = $projectorRef->newInstanceWithoutConstructor();
+
+        $this->assertTrue($shouldUpdateLock->invoke($projector, new \DateTimeImmutable('now', new \DateTimeZone('UTC'))));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_update_lock_if_update_lock_threshold_is_set_to_0()
+    {
+        $projectorRef = new \ReflectionClass(PdoEventStoreProjector::class);
+
+        $shouldUpdateLock = new \ReflectionMethod(PdoEventStoreProjector::class, 'shouldUpdateLock');
+
+        $shouldUpdateLock->setAccessible(true);
+
+        $projector = $projectorRef->newInstanceWithoutConstructor();
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $lastLockUpdateProp = $projectorRef->getProperty('lastLockUpdate');
+        $lastLockUpdateProp->setAccessible(true);
+        $lastLockUpdateProp->setValue($projector, $now);
+
+        $updateLockThresholdProp = $projectorRef->getProperty('updateLockThreshold');
+        $updateLockThresholdProp->setAccessible(true);
+        $updateLockThresholdProp->setValue($projector, 0);
+
+        $this->assertTrue($shouldUpdateLock->invoke($projector, $now));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_update_lock_if_now_is_greater_than_last_lock_update_plus_threshold()
+    {
+        $projectorRef = new \ReflectionClass(PdoEventStoreProjector::class);
+
+        $shouldUpdateLock = new \ReflectionMethod(PdoEventStoreProjector::class, 'shouldUpdateLock');
+
+        $shouldUpdateLock->setAccessible(true);
+
+        $projector = $projectorRef->newInstanceWithoutConstructor();
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $lastLockUpdateProp = $projectorRef->getProperty('lastLockUpdate');
+        $lastLockUpdateProp->setAccessible(true);
+        $lastLockUpdateProp->setValue($projector, TestUtil::subMilliseconds($now, 800));
+
+        $updateLockThresholdProp = $projectorRef->getProperty('updateLockThreshold');
+        $updateLockThresholdProp->setAccessible(true);
+        $updateLockThresholdProp->setValue($projector, 500);
+
+        $this->assertTrue($shouldUpdateLock->invoke($projector, $now));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_update_lock_if_now_is_lower_than_last_lock_update_plus_threshold()
+    {
+        $projectorRef = new \ReflectionClass(PdoEventStoreProjector::class);
+
+        $shouldUpdateLock = new \ReflectionMethod(PdoEventStoreProjector::class, 'shouldUpdateLock');
+
+        $shouldUpdateLock->setAccessible(true);
+
+        $projector = $projectorRef->newInstanceWithoutConstructor();
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $lastLockUpdateProp = $projectorRef->getProperty('lastLockUpdate');
+        $lastLockUpdateProp->setAccessible(true);
+        $lastLockUpdateProp->setValue($projector, TestUtil::subMilliseconds($now, 300));
+
+        $updateLockThresholdProp = $projectorRef->getProperty('updateLockThreshold');
+        $updateLockThresholdProp->setAccessible(true);
+        $updateLockThresholdProp->setValue($projector, 500);
+
+        $this->assertFalse($shouldUpdateLock->invoke($projector, $now));
+    }
 }

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -245,7 +245,7 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
         $processDetails = proc_get_status($projectionProcess);
 
-        usleep(100000);
+        sleep(2);
 
         $lockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 

--- a/tests/Projection/PdoEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorTest.php
@@ -245,21 +245,21 @@ abstract class PdoEventStoreReadModelProjectorTest extends AbstractEventStoreRea
         $projectionProcess = proc_open($command, $descriptorSpec, $pipes);
         $processDetails = proc_get_status($projectionProcess);
 
-        sleep(2);
+        sleep(1);
 
         $lockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 
         $this->assertNotNull($lockedUntil);
 
-        //Update lock threshold is set to 500 ms
-        usleep(200000);
+        //Update lock threshold is set to 2000 ms
+        usleep(500000);
 
         $notUpdatedLockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 
         $this->assertEquals($lockedUntil, $notUpdatedLockedUntil);
 
         //Now we should definitely see an updated lock
-        usleep(800000);
+        sleep(2);
 
         $updatedLockedUntil = TestUtil::getProjectionLockedUntilFromDefaultProjectionsTable($this->connection, 'test_projection');
 

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -36,7 +36,8 @@ $projection = $projectionManager->createProjection(
     'test_projection',
     [
         PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true,
-        PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD => 500,
+        PdoEventStoreProjector::OPTION_LOCK_TIMEOUT_MS => 3000,
+        PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD => 2000,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -36,6 +36,7 @@ $projection = $projectionManager->createProjection(
     'test_projection',
     [
         PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true,
+        PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD => 500,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -65,7 +65,8 @@ $projection = $projectionManager->createReadModelProjection(
     $readModel,
     [
         PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH => true,
-        PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD => 500,
+        PdoEventStoreReadModelProjector::OPTION_LOCK_TIMEOUT_MS => 3000,
+        PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD => 2000,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -14,7 +14,7 @@ use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
-use Prooph\EventStore\Pdo\Projection\PdoEventStoreProjector;
+use Prooph\EventStore\Pdo\Projection\PdoEventStoreReadModelProjector;
 use Prooph\EventStore\Projection\ReadModel;
 use ProophTest\EventStore\Mock\UserCreated;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -64,7 +64,8 @@ $projection = $projectionManager->createReadModelProjection(
     'test_projection',
     $readModel,
     [
-        PdoEventStoreProjector::OPTION_PCNTL_DISPATCH => true,
+        PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH => true,
+        PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD => 500,
     ]
 );
 pcntl_signal(SIGQUIT, function () use ($projection) {

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -180,6 +180,16 @@ abstract class TestUtil
         return null;
     }
 
+    public static function subMilliseconds(\DateTimeImmutable $time, int $ms): \DateTimeImmutable
+    {
+        //Create a 0 interval
+        $interval = new \DateInterval('PT0S');
+        //and manually add split seconds
+        $interval->f = $ms / 1000;
+
+        return $time->sub($interval);
+    }
+
     private static function hasRequiredConnectionParams(): bool
     {
         $env = getenv();

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -155,6 +155,31 @@ abstract class TestUtil
         }
     }
 
+    public static function getProjectionLockedUntilFromDefaultProjectionsTable(PDO $connection, string $projectionName): ?\DateTimeImmutable
+    {
+        $vendor = self::getDatabaseVendor();
+
+        $projectionsTable = '`projections`';
+
+        if ($vendor === 'postgres') {
+            $projectionsTable = '"projections"';
+        }
+
+        $sql = "SELECT locked_until FROM $projectionsTable WHERE name = ?";
+
+        $statement = $connection->prepare($sql);
+
+        $statement->execute([$projectionName]);
+
+        $lockedUntil = $statement->fetchColumn();
+
+        if ($lockedUntil) {
+            return \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', $lockedUntil, new \DateTimeZone('UTC'));
+        }
+
+        return null;
+    }
+
     private static function hasRequiredConnectionParams(): bool
     {
         $env = getenv();


### PR DESCRIPTION
This PR provides the implementation for the new projection option `update lock threshold`, see https://github.com/prooph/event-store/pull/331
