### PR TITLE
Use MessageConverter in persistence strategies

### DIFF
--- a/src/CompatibilityMessageConverter.php
+++ b/src/CompatibilityMessageConverter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo;
+
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+
+/**
+ * @deprecated This class is used for backwards compatibility. It's recommended to use a different MessageConverter implementation such as \Prooph\Common\Messaging\NoOpMessageConverter.
+ */
+class CompatibilityMessageConverter implements MessageConverter
+{
+    public function convertToArray(Message $message): array
+    {
+        return [
+           'message_name' => $message->messageName(),
+           'uuid' => $message->uuid()->toString(),
+           'payload' => $message->payload(),
+           'metadata' => $message->metadata(),
+           'created_at' => $message->createdAt(),
+        ];
+    }
+}

--- a/src/DefaultMessageConverter.php
+++ b/src/DefaultMessageConverter.php
@@ -15,10 +15,7 @@ namespace Prooph\EventStore\Pdo;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageConverter;
 
-/**
- * @deprecated This class is used for backwards compatibility. It's recommended to use a different MessageConverter implementation such as \Prooph\Common\Messaging\NoOpMessageConverter.
- */
-class CompatibilityMessageConverter implements MessageConverter
+class DefaultMessageConverter implements MessageConverter
 {
     public function convertToArray(Message $message): array
     {

--- a/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
@@ -29,7 +29,7 @@ final class MariaDbAggregateStreamStrategy implements PersistenceStrategy, Maria
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
@@ -26,9 +27,9 @@ final class MariaDbAggregateStreamStrategy implements PersistenceStrategy, Maria
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -24,9 +25,9 @@ final class MariaDbSimpleStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -27,7 +27,7 @@ final class MariaDbSimpleStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
@@ -13,11 +13,22 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class MariaDbSimpleStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -58,11 +69,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
@@ -26,9 +27,9 @@ final class MariaDbSingleStreamStrategy implements PersistenceStrategy, HasQuery
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
@@ -29,7 +29,7 @@ final class MariaDbSingleStreamStrategy implements PersistenceStrategy, HasQuery
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
@@ -20,6 +21,16 @@ use Prooph\EventStore\StreamName;
 
 final class MariaDbSingleStreamStrategy implements PersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -74,11 +85,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -25,9 +26,9 @@ final class MySqlAggregateStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
@@ -13,12 +13,23 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class MySqlAggregateStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -59,16 +70,18 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            if (! isset($event->metadata()['_aggregate_version'])) {
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            if (! isset($eventData['metadata']['_aggregate_version'])) {
                 throw new Exception\RuntimeException('_aggregate_version is missing in metadata');
             }
 
-            $data[] = $event->metadata()['_aggregate_version'];
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $data[] = $eventData['metadata']['_aggregate_version'];
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -28,7 +28,7 @@ final class MySqlAggregateStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -27,7 +27,7 @@ final class MySqlSimpleStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
@@ -13,11 +13,22 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class MySqlSimpleStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -56,11 +67,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -24,9 +25,9 @@ final class MySqlSimpleStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -13,12 +13,23 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class MySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHint
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -62,11 +73,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -25,9 +26,9 @@ final class MySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHi
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -28,7 +28,7 @@ final class MySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHi
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -28,7 +28,7 @@ final class PostgresAggregateStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -13,12 +13,23 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class PostgresAggregateStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -61,16 +72,18 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            if (! isset($event->metadata()['_aggregate_version'])) {
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            if (! isset($eventData['metadata']['_aggregate_version'])) {
                 throw new Exception\RuntimeException('_aggregate_version is missing in metadata');
             }
 
-            $data[] = $event->metadata()['_aggregate_version'];
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $data[] = $eventData['metadata']['_aggregate_version'];
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
@@ -25,9 +26,9 @@ final class PostgresAggregateStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -13,11 +13,22 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class PostgresSimpleStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -58,11 +69,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -24,9 +25,9 @@ final class PostgresSimpleStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -27,7 +27,7 @@ final class PostgresSimpleStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -13,11 +13,22 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
 final class PostgresSingleStreamStrategy implements PersistenceStrategy
 {
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
     /**
      * @param string $tableName
      * @return string[]
@@ -73,11 +84,13 @@ EOT;
         $data = [];
 
         foreach ($streamEvents as $event) {
-            $data[] = $event->uuid()->toString();
-            $data[] = $event->messageName();
-            $data[] = json_encode($event->payload());
-            $data[] = json_encode($event->metadata());
-            $data[] = $event->createdAt()->format('Y-m-d\TH:i:s.u');
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload']);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
         }
 
         return $data;

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -14,7 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
-use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -27,7 +27,7 @@ final class PostgresSingleStreamStrategy implements PersistenceStrategy
 
     public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
     }
 
     /**

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -14,6 +14,7 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\CompatibilityMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
 
@@ -24,9 +25,9 @@ final class PostgresSingleStreamStrategy implements PersistenceStrategy
      */
     private $messageConverter;
 
-    public function __construct(MessageConverter $messageConverter)
+    public function __construct(?MessageConverter $messageConverter = null)
     {
-        $this->messageConverter = $messageConverter;
+        $this->messageConverter = $messageConverter ?? new CompatibilityMessageConverter();
     }
 
     /**

--- a/tests/Container/MariaDbEventStoreFactoryTest.php
+++ b/tests/Container/MariaDbEventStoreFactoryTest.php
@@ -48,7 +48,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new MariaDbEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -73,7 +73,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = MariaDbEventStoreFactory::$eventStoreName($container->reveal());
@@ -99,7 +99,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -133,7 +133,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -162,7 +162,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -194,7 +194,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MariaDbAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 

--- a/tests/Container/MySqlEventStoreFactoryTest.php
+++ b/tests/Container/MySqlEventStoreFactoryTest.php
@@ -48,7 +48,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new MySqlEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -73,7 +73,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = MySqlEventStoreFactory::$eventStoreName($container->reveal());
@@ -99,7 +99,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -133,7 +133,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -162,7 +162,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -194,7 +194,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\MySqlAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 

--- a/tests/Container/PostgresEventStoreFactoryTest.php
+++ b/tests/Container/PostgresEventStoreFactoryTest.php
@@ -49,7 +49,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new PostgresEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -74,7 +74,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = PostgresEventStoreFactory::$eventStoreName($container->reveal());
@@ -100,7 +100,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -134,7 +134,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -163,7 +163,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -195,7 +195,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn(new PersistenceStrategy\PostgresAggregateStreamStrategy())->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 

--- a/tests/MariaDbEventStoreTest.php
+++ b/tests/MariaDbEventStoreTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Pdo;
 use ArrayIterator;
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
@@ -48,7 +49,7 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $this->setupEventStoreWith(new MariaDbAggregateStreamStrategy());
+        $this->setupEventStoreWith(new MariaDbAggregateStreamStrategy(new NoOpMessageConverter()));
     }
 
     /**
@@ -75,7 +76,7 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_loads_correctly_using_single_stream_per_aggregate_type_strategy(): void
     {
-        $this->setupEventStoreWith(new MariaDbSingleStreamStrategy(), 5);
+        $this->setupEventStoreWith(new MariaDbSingleStreamStrategy(new NoOpMessageConverter()), 5);
 
         $streamName = new StreamName('Prooph\Model\User');
 
@@ -106,7 +107,7 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
     {
         $this->expectException(ConcurrencyException::class);
 
-        $this->setupEventStoreWith(new MariaDbSingleStreamStrategy());
+        $this->setupEventStoreWith(new MariaDbSingleStreamStrategy(new NoOpMessageConverter()));
 
         $streamEvent = UserCreated::with(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
@@ -142,7 +143,7 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
         $connection->commit()->shouldNotBeCalled();
         $connection->rollback()->shouldNotBeCalled();
 
-        $eventStore = new MariaDbEventStore(new FQCNMessageFactory(), $connection->reveal(), new MariaDbAggregateStreamStrategy());
+        $eventStore = new MariaDbEventStore(new FQCNMessageFactory(), $connection->reveal(), new MariaDbAggregateStreamStrategy(new NoOpMessageConverter()));
 
         $streamEvent = UserCreated::with(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],

--- a/tests/MySqlEventStoreTest.php
+++ b/tests/MySqlEventStoreTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Pdo;
 use ArrayIterator;
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\FieldType;
 use Prooph\EventStore\Metadata\MetadataMatcher;
@@ -50,7 +51,7 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $this->setupEventStoreWith(new MySqlAggregateStreamStrategy());
+        $this->setupEventStoreWith(new MySqlAggregateStreamStrategy(new NoOpMessageConverter()));
     }
 
     /**
@@ -77,7 +78,7 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_loads_correctly_using_single_stream_per_aggregate_type_strategy(): void
     {
-        $this->setupEventStoreWith(new MySqlSingleStreamStrategy(), 5);
+        $this->setupEventStoreWith(new MySqlSingleStreamStrategy(new NoOpMessageConverter()), 5);
 
         $streamName = new StreamName('Prooph\Model\User');
 
@@ -108,7 +109,7 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
     {
         $this->expectException(ConcurrencyException::class);
 
-        $this->setupEventStoreWith(new MySqlSingleStreamStrategy());
+        $this->setupEventStoreWith(new MySqlSingleStreamStrategy(new NoOpMessageConverter()));
 
         $streamEvent = UserCreated::with(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
@@ -144,7 +145,7 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
         $connection->commit()->shouldNotBeCalled();
         $connection->rollback()->shouldNotBeCalled();
 
-        $eventStore = new MySqlEventStore(new FQCNMessageFactory(), $connection->reveal(), new MySqlAggregateStreamStrategy());
+        $eventStore = new MySqlEventStore(new FQCNMessageFactory(), $connection->reveal(), new MySqlAggregateStreamStrategy(new NoOpMessageConverter()));
 
         $streamEvent = UserCreated::with(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],

--- a/tests/PostgresEventStoreTest.php
+++ b/tests/PostgresEventStoreTest.php
@@ -14,6 +14,7 @@ namespace ProophTest\EventStore\Pdo;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
@@ -50,7 +51,7 @@ class PostgresEventStoreTest extends AbstractPdoEventStoreTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $this->setupEventStoreWith(new PostgresAggregateStreamStrategy());
+        $this->setupEventStoreWith(new PostgresAggregateStreamStrategy(new NoOpMessageConverter()));
     }
 
     /**
@@ -77,7 +78,7 @@ class PostgresEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_loads_correctly_using_single_stream_per_aggregate_type_strategy(): void
     {
-        $this->setupEventStoreWith(new PostgresSingleStreamStrategy(), 5);
+        $this->setupEventStoreWith(new PostgresSingleStreamStrategy(new NoOpMessageConverter()), 5);
 
         $streamName = new StreamName('Prooph\Model\User');
 
@@ -108,7 +109,7 @@ class PostgresEventStoreTest extends AbstractPdoEventStoreTest
     {
         $this->expectException(ConcurrencyException::class);
 
-        $this->setupEventStoreWith(new PostgresSingleStreamStrategy());
+        $this->setupEventStoreWith(new PostgresSingleStreamStrategy(new NoOpMessageConverter()));
 
         $streamEvent = UserCreated::with(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
@@ -144,7 +145,7 @@ class PostgresEventStoreTest extends AbstractPdoEventStoreTest
         $connection->commit()->shouldNotBeCalled();
         $connection->rollback()->shouldNotBeCalled();
 
-        $eventStore = new PostgresEventStore(new FQCNMessageFactory(), $connection->reveal(), new PostgresAggregateStreamStrategy());
+        $eventStore = new PostgresEventStore(new FQCNMessageFactory(), $connection->reveal(), new PostgresAggregateStreamStrategy(new NoOpMessageConverter()));
 
         $eventStore->beginTransaction();
         $eventStore->commit();

--- a/tests/Projection/MariaDbEventStoreProjectorCustomTablesTest.php
+++ b/tests/Projection/MariaDbEventStoreProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -36,7 +37,7 @@ class MariaDbEventStoreProjectorCustomTablesTest extends PdoEventStoreProjectorC
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy(),
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/MariaDbEventStoreProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -36,7 +37,7 @@ class MariaDbEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy()
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MariaDbProjectionManager(

--- a/tests/Projection/MariaDbEventStoreQueryCustomTablesTest.php
+++ b/tests/Projection/MariaDbEventStoreQueryCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -35,7 +36,7 @@ class MariaDbEventStoreQueryCustomTablesTest extends PdoEventStoreQueryCustomTab
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy(),
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/MariaDbEventStoreQueryTest.php
+++ b/tests/Projection/MariaDbEventStoreQueryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -35,7 +36,7 @@ class MariaDbEventStoreQueryTest extends PdoEventStoreQueryTest
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy()
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MariaDbProjectionManager(

--- a/tests/Projection/MariaDbEventStoreReadModelProjectorCustomTablesTest.php
+++ b/tests/Projection/MariaDbEventStoreReadModelProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -38,7 +39,7 @@ class MariaDbEventStoreReadModelProjectorCustomTablesTest extends PdoEventStoreR
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy(),
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
 

--- a/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -38,7 +39,7 @@ class MariaDbEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProj
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbSimpleStreamStrategy()
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MariaDbProjectionManager(

--- a/tests/Projection/MariaDbProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/MariaDbProjectionManagerCustomTablesTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -53,10 +53,12 @@ class MariaDbProjectionManagerCustomTablesTest extends AbstractProjectionManager
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbAggregateStreamStrategy(),
+            $persistenceStrategy,
             10000,
             'events/streams'
         );

--- a/tests/Projection/MariaDbProjectionManagerTest.php
+++ b/tests/Projection/MariaDbProjectionManagerTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -53,10 +53,12 @@ class MariaDbProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MariaDbAggregateStreamStrategy()
+            $persistenceStrategy
         );
         $this->projectionManager = new MariaDbProjectionManager($this->eventStore, $this->connection);
     }

--- a/tests/Projection/MySqlEventStoreProjectorCustomTablesTest.php
+++ b/tests/Projection/MySqlEventStoreProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -36,7 +37,7 @@ class MySqlEventStoreProjectorCustomTablesTest extends PdoEventStoreProjectorCus
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy(),
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/MySqlEventStoreProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -36,7 +37,7 @@ class MySqlEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy()
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MySqlProjectionManager(

--- a/tests/Projection/MySqlEventStoreQueryCustomTablesTest.php
+++ b/tests/Projection/MySqlEventStoreQueryCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -37,7 +38,7 @@ class MySqlEventStoreQueryCustomTablesTest extends PdoEventStoreQueryCustomTable
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy(),
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/MySqlEventStoreQueryTest.php
+++ b/tests/Projection/MySqlEventStoreQueryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -37,7 +38,7 @@ class MySqlEventStoreQueryTest extends PdoEventStoreQueryTest
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy()
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MySqlProjectionManager(

--- a/tests/Projection/MySqlEventStoreReadModelProjectorCustomTablesTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -38,7 +39,7 @@ class MySqlEventStoreReadModelProjectorCustomTablesTest extends PdoEventStoreRea
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy(),
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -38,7 +39,7 @@ class MySqlEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProjec
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlSimpleStreamStrategy()
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new MySqlProjectionManager(

--- a/tests/Projection/MySqlProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/MySqlProjectionManagerCustomTablesTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -53,10 +53,12 @@ class MySqlProjectionManagerCustomTablesTest extends AbstractProjectionManagerTe
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlAggregateStreamStrategy(),
+            $persistenceStrategy,
             10000,
             'events/streams'
 

--- a/tests/Projection/MySqlProjectionManagerTest.php
+++ b/tests/Projection/MySqlProjectionManagerTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -53,10 +53,12 @@ class MySqlProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new MySqlAggregateStreamStrategy()
+            $persistenceStrategy
         );
         $this->projectionManager = new MySqlProjectionManager($this->eventStore, $this->connection);
     }

--- a/tests/Projection/PostgresEventStoreProjectorCustomTablesTest.php
+++ b/tests/Projection/PostgresEventStoreProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -36,7 +37,7 @@ class PostgresEventStoreProjectorCustomTablesTest extends PdoEventStoreProjector
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy(),
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
         );

--- a/tests/Projection/PostgresEventStoreProjectorTest.php
+++ b/tests/Projection/PostgresEventStoreProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -36,7 +37,7 @@ class PostgresEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy()
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new PostgresProjectionManager(

--- a/tests/Projection/PostgresEventStoreQueryCustomTablesTest.php
+++ b/tests/Projection/PostgresEventStoreQueryCustomTablesTest.php
@@ -14,6 +14,7 @@ namespace ProophTest\EventStore\Pdo\Projection;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -36,7 +37,7 @@ class PostgresEventStoreQueryCustomTablesTest extends PdoEventStoreQueryCustomTa
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy(),
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
 

--- a/tests/Projection/PostgresEventStoreQueryTest.php
+++ b/tests/Projection/PostgresEventStoreQueryTest.php
@@ -14,6 +14,7 @@ namespace ProophTest\EventStore\Pdo\Projection;
 
 use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -36,7 +37,7 @@ class PostgresEventStoreQueryTest extends PdoEventStoreQueryTest
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy()
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new PostgresProjectionManager(

--- a/tests/Projection/PostgresEventStoreReadModelProjectorCustomTablesTest.php
+++ b/tests/Projection/PostgresEventStoreReadModelProjectorCustomTablesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -37,7 +38,7 @@ class PostgresEventStoreReadModelProjectorCustomTablesTest extends PdoEventStore
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy(),
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter()),
             10000,
             'events/streams'
 

--- a/tests/Projection/PostgresEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PostgresEventStoreReadModelProjectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -37,7 +38,7 @@ class PostgresEventStoreReadModelProjectorTest extends PdoEventStoreReadModelPro
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             TestUtil::getConnection(),
-            new PostgresSimpleStreamStrategy()
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
         );
 
         $this->projectionManager = new PostgresProjectionManager(

--- a/tests/Projection/PostgresProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/PostgresProjectionManagerCustomTablesTest.php
@@ -18,7 +18,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
@@ -54,14 +54,16 @@ class PostgresProjectionManagerCustomTablesTest extends AbstractProjectionManage
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new PostgresAggregateStreamStrategy(),
+            $persistenceStrategy,
             10000,
             'events/streams'
-
         );
+
         $this->projectionManager = new PostgresProjectionManager(
             $this->eventStore,
             $this->connection,

--- a/tests/Projection/PostgresProjectionManagerTest.php
+++ b/tests/Projection/PostgresProjectionManagerTest.php
@@ -18,7 +18,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
@@ -54,10 +54,12 @@ class PostgresProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
+        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),
             $this->connection,
-            new PostgresAggregateStreamStrategy()
+            $persistenceStrategy
         );
         $this->projectionManager = new PostgresProjectionManager($this->eventStore, $this->connection);
     }

--- a/tests/Projection/isolated-projection.php
+++ b/tests/Projection/isolated-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -25,7 +26,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MySqlEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MySqlSimpleStreamStrategy()
+    new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
 );
 
 $projectionManager = new MySqlProjectionManager(

--- a/tests/Projection/isolated-read-model-projection.php
+++ b/tests/Projection/isolated-read-model-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -53,7 +54,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MySqlEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MySqlSimpleStreamStrategy()
+    new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
 );
 
 $projectionManager = new MySqlProjectionManager(

--- a/tests/Projection/mariadb-isolated-long-running-projection.php
+++ b/tests/Projection/mariadb-isolated-long-running-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -27,7 +28,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MariaDbEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MariaDbSimpleStreamStrategy()
+    new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/mariadb-isolated-long-running-query.php
+++ b/tests/Projection/mariadb-isolated-long-running-query.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -27,7 +28,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MariaDbEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MariaDbSimpleStreamStrategy()
+    new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/mariadb-isolated-long-running-read-model-projection.php
+++ b/tests/Projection/mariadb-isolated-long-running-read-model-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -55,7 +56,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MariaDbEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MariaDbSimpleStreamStrategy()
+    new MariaDbSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/mysql-isolated-long-running-projection.php
+++ b/tests/Projection/mysql-isolated-long-running-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -27,7 +28,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MySqlEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MySqlSimpleStreamStrategy()
+    new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/mysql-isolated-long-running-query.php
+++ b/tests/Projection/mysql-isolated-long-running-query.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -26,7 +27,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MySqlEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MySqlSimpleStreamStrategy()
+    new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/mysql-isolated-long-running-read-model-projection.php
+++ b/tests/Projection/mysql-isolated-long-running-read-model-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -55,7 +56,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new MySqlEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new MySqlSimpleStreamStrategy()
+    new MySqlSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/postgres-isolated-long-running-projection.php
+++ b/tests/Projection/postgres-isolated-long-running-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -27,7 +28,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new PostgresEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new PostgresSimpleStreamStrategy()
+    new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/postgres-isolated-long-running-query.php
+++ b/tests/Projection/postgres-isolated-long-running-query.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -27,7 +28,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new PostgresEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new PostgresSimpleStreamStrategy()
+    new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 

--- a/tests/Projection/postgres-isolated-long-running-read-model-projection.php
+++ b/tests/Projection/postgres-isolated-long-running-read-model-projection.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -55,7 +56,7 @@ $connection = TestUtil::getConnection();
 $eventStore = new PostgresEventStore(
     new FQCNMessageFactory(),
     $connection,
-    new PostgresSimpleStreamStrategy()
+    new PostgresSimpleStreamStrategy(new NoOpMessageConverter())
 );
 $events = [];
 


### PR DESCRIPTION
I wanted to change the behavior how a message is serialized (I'm not using `Message::payload()`). In order to do so I was forced to implement a custom persistence strategy.

In my opinion it's not a responsibility of a PersistenceStrategy to do the serialization. And it's not a responsibility of a Message either in my setup.

Recently I found a MessageConverter interface in Prooph/Common and I believe the responsibility belongs there and so it should be used here in the persistence strategies. Then I could simply change the converter implementation.

Note: I would like to remove the payload method from Message interface later in another PR and move it to DomainMessage or a new MessageWithPayload interface.