### PR TITLE
Pg schema support

### DIFF
--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -15,17 +15,21 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\StreamName;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
 
 final class PostgresSimpleStreamStrategy implements PersistenceStrategy
 {
+    use PostgresHelper;
     /**
      * @param string $tableName
      * @return string[]
      */
     public function createSchema(string $tableName): array
     {
+        $tableName = $this->quoteIdent($tableName);
+
         $statement = <<<EOT
-CREATE TABLE "$tableName" (
+CREATE TABLE $tableName (
     no BIGSERIAL,
     event_id UUID NOT NULL,
     event_name VARCHAR(100) NOT NULL,
@@ -70,6 +74,9 @@ EOT;
 
     public function generateTableName(StreamName $streamName): string
     {
-        return '_' . sha1($streamName->toString());
+        return implode('.', array_filter([
+            $this->extractSchema($streamName->toString()),
+            '_' . sha1($streamName->toString()),
+        ]));
     }
 }

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -27,6 +27,7 @@ use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\ProjectionNotCreatedException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\PdoEventStore;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\Projection\ProjectionStatus;
 use Prooph\EventStore\Projection\Projector;
 use Prooph\EventStore\Stream;
@@ -35,6 +36,11 @@ use Prooph\EventStore\Util\ArrayCache;
 
 final class PdoEventStoreProjector implements Projector
 {
+    use PostgresHelper {
+        quoteIdent as pgQuoteIdent;
+        extractSchema as pgExtractSchema;
+    }
+
     private const UNIQUE_VIOLATION_ERROR_CODES = [
         'pgsql' => '23505',
         'mysql' => '23000',
@@ -978,7 +984,7 @@ EOT;
     {
         switch ($this->vendor) {
             case 'pgsql':
-                return '"'.$tableName.'"';
+                return $this->pgQuoteIdent($tableName);
             default:
                 return "`$tableName`";
         }

--- a/src/Projection/PdoEventStoreQuery.php
+++ b/src/Projection/PdoEventStoreQuery.php
@@ -22,11 +22,16 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\PdoEventStore;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\Projection\Query;
 use Prooph\EventStore\StreamName;
 
 final class PdoEventStoreQuery implements Query
 {
+    use PostgresHelper {
+        quoteIdent as pgQuoteIdent;
+        extractSchema as pgExtractSchema;
+    }
     /**
      * @var EventStore
      */
@@ -436,7 +441,7 @@ EOT;
     {
         switch ($this->vendor) {
             case 'pgsql':
-                return '"'.$tableName.'"';
+                return $this->pgQuoteIdent($tableName);
             default:
                 return "`$tableName`";
         }

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -24,6 +24,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\PdoEventStore;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\Projection\ProjectionStatus;
 use Prooph\EventStore\Projection\ReadModel;
 use Prooph\EventStore\Projection\ReadModelProjector;
@@ -31,6 +32,10 @@ use Prooph\EventStore\StreamName;
 
 final class PdoEventStoreReadModelProjector implements ReadModelProjector
 {
+    use PostgresHelper {
+        quoteIdent as pgQuoteIdent;
+        extractSchema as pgExtractSchema;
+    }
     /**
      * @var EventStore
      */
@@ -925,7 +930,7 @@ EOT;
     {
         switch ($this->vendor) {
             case 'pgsql':
-                return '"'.$tableName.'"';
+                return $this->pgQuoteIdent($tableName);
             default:
                 return "`$tableName`";
         }

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -20,6 +20,7 @@ use Prooph\EventStore\Exception\OutOfRangeException;
 use Prooph\EventStore\Exception\ProjectionNotFound;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Projection\ProjectionStatus;
 use Prooph\EventStore\Projection\Projector;
@@ -29,6 +30,7 @@ use Prooph\EventStore\Projection\ReadModelProjector;
 
 final class PostgresProjectionManager implements ProjectionManager
 {
+    use PostgresHelper;
     /**
      * @var EventStore
      */
@@ -121,7 +123,7 @@ final class PostgresProjectionManager implements ProjectionManager
     public function deleteProjection(string $name, bool $deleteEmittedEvents): void
     {
         $sql = <<<EOT
-UPDATE "$this->projectionsTable" SET status = ? WHERE name = ?;
+UPDATE {$this->quoteIdent($this->projectionsTable)} SET status = ? WHERE name = ?;
 EOT;
 
         if ($deleteEmittedEvents) {
@@ -152,7 +154,7 @@ EOT;
     public function resetProjection(string $name): void
     {
         $sql = <<<EOT
-UPDATE "$this->projectionsTable" SET status = ? WHERE name = ?;
+UPDATE {$this->quoteIdent($this->projectionsTable)} SET status = ? WHERE name = ?;
 EOT;
 
         $statement = $this->connection->prepare($sql);
@@ -177,7 +179,7 @@ EOT;
     public function stopProjection(string $name): void
     {
         $sql = <<<EOT
-UPDATE "$this->projectionsTable" SET status = ? WHERE name = ?;
+UPDATE {$this->quoteIdent($this->projectionsTable)} SET status = ? WHERE name = ?;
 EOT;
 
         $statement = $this->connection->prepare($sql);
@@ -223,7 +225,7 @@ EOT;
         }
 
         $query = <<<SQL
-SELECT name FROM "$this->projectionsTable"
+SELECT name FROM {$this->quoteIdent($this->projectionsTable)}
 $whereCondition
 ORDER BY name ASC
 LIMIT $limit OFFSET $offset
@@ -275,7 +277,7 @@ SQL;
 
         $whereCondition = 'WHERE name ~ :filter';
         $query = <<<SQL
-SELECT name FROM "$this->projectionsTable"
+SELECT name FROM {$this->quoteIdent($this->projectionsTable)}
 $whereCondition
 ORDER BY name ASC
 LIMIT $limit OFFSET $offset
@@ -314,7 +316,7 @@ SQL;
     public function fetchProjectionStatus(string $name): ProjectionStatus
     {
         $query = <<<SQL
-SELECT status FROM "$this->projectionsTable"
+SELECT status FROM {$this->quoteIdent($this->projectionsTable)}
 WHERE name = ?
 LIMIT 1
 SQL;
@@ -343,7 +345,7 @@ SQL;
     public function fetchProjectionStreamPositions(string $name): array
     {
         $query = <<<SQL
-SELECT position FROM "$this->projectionsTable"
+SELECT position FROM {$this->quoteIdent($this->projectionsTable)}
 WHERE name = ?
 LIMIT 1
 SQL;
@@ -372,7 +374,7 @@ SQL;
     public function fetchProjectionState(string $name): array
     {
         $query = <<<SQL
-SELECT state FROM "$this->projectionsTable"
+SELECT state FROM {$this->quoteIdent($this->projectionsTable)}
 WHERE name = ?
 LIMIT 1
 SQL;

--- a/src/Util/PostgresHelper.php
+++ b/src/Util/PostgresHelper.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\Util;
+
+trait PostgresHelper {
+    /**
+     * @param string $tableName
+     * @return string
+     */
+    private function quoteIdent(string $tableName): string
+    {
+        return array_reduce(explode('.', $tableName), function ($result, $part) {
+            return implode('.', array_filter([
+                $result,
+                '"' . trim($part, '" ') . '"',
+            ]));
+        }, '');
+    }
+
+    /**
+     * @param string $identifier
+     * @return string|null
+     */
+    private function extractSchema(string $identifier): ?string
+    {
+        $parts = array_map(function ($part) {
+            return trim($part, '" ');
+        }, explode('.', $identifier));
+
+        return count($parts) === 2 ? $parts[0] : null;
+    }
+}

--- a/tests/Assets/scripts/postgres/01_custom_event_streams_table.sql
+++ b/tests/Assets/scripts/postgres/01_custom_event_streams_table.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS custom;
+
+CREATE TABLE custom.event_streams (
+  no BIGSERIAL,
+  real_stream_name VARCHAR(150) NOT NULL,
+  stream_name CHAR(150) NOT NULL,
+  metadata JSONB,
+  category VARCHAR(150),
+  PRIMARY KEY (no),
+  UNIQUE (stream_name)
+);
+CREATE INDEX on custom.event_streams (category);

--- a/tests/Assets/scripts/postgres/02_custom_projections_table.sql
+++ b/tests/Assets/scripts/postgres/02_custom_projections_table.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS custom;
+
+CREATE TABLE custom.event_projections (
+  no BIGSERIAL,
+  name VARCHAR(150) NOT NULL,
+  position JSONB,
+  state JSONB,
+  status VARCHAR(28) NOT NULL,
+  locked_until CHAR(26),
+  PRIMARY KEY (no),
+  UNIQUE (name)
+);

--- a/tests/PostgresCustomSchemaEventStoreTest.php
+++ b/tests/PostgresCustomSchemaEventStoreTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo;
+
+use PDO;
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Exception\ConcurrencyException;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Mock\UsernameChanged;
+use ProophTest\EventStore\TransactionalEventStoreTestTrait;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @group postgres
+ */
+class PostgresCustomSchemaEventStoreTest extends AbstractPdoEventStoreTest
+{
+    use TransactionalEventStoreTestTrait;
+
+    /**
+     * @var PostgresEventStore
+     */
+    protected $eventStore;
+
+    protected function setUp(): void
+    {
+        if (TestUtil::getDatabaseDriver() !== 'pdo_pgsql') {
+            throw new \RuntimeException('Invalid database vendor');
+        }
+
+        $this->connection = TestUtil::getConnection();
+        TestUtil::initCustomSchemaDatabaseTables($this->connection);
+
+        $this->setupEventStoreWith(new PostgresAggregateStreamStrategy(), 10000, $this->eventStreamsTable());
+    }
+
+    protected function eventStreamsTable(): string
+    {
+        return 'custom.event_streams';
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_create_new_stream_if_table_name_is_already_used(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Error during createSchemaFor');
+
+        $streamName = new StreamName('custom.foo');
+        $schema = $this->persistenceStrategy->createSchema($this->persistenceStrategy->generateTableName($streamName));
+
+        foreach ($schema as $command) {
+            $statement = $this->connection->prepare($command);
+            $statement->execute();
+        }
+
+        $this->eventStore->create(new Stream($streamName, new \ArrayIterator()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_correctly_using_single_stream_per_aggregate_type_strategy(): void
+    {
+        $this->setupEventStoreWith(new PostgresSingleStreamStrategy(), 5, $this->eventStreamsTable());
+
+        $streamName = new StreamName('custom.Prooph\Model\User');
+
+        $stream = new Stream($streamName, new \ArrayIterator($this->getMultipleTestEvents()));
+
+        $this->eventStore->create($stream);
+
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('_aggregate_id', Operator::EQUALS(), 'one');
+        $events = iterator_to_array($this->eventStore->load($streamName, 1, null, $metadataMatcher));
+        $this->assertCount(100, $events);
+        $lastUser1Event = array_pop($events);
+
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('_aggregate_id', Operator::EQUALS(), 'two');
+        $events = iterator_to_array($this->eventStore->load($streamName, 1, null, $metadataMatcher));
+        $this->assertCount(100, $events);
+        $lastUser2Event = array_pop($events);
+
+        $this->assertEquals('Sandro', $lastUser1Event->payload()['name']);
+        $this->assertEquals('Bradley', $lastUser2Event->payload()['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_to_write_with_duplicate_version_and_mulitple_streams_per_aggregate_strategy(): void
+    {
+        $this->expectException(ConcurrencyException::class);
+
+        $this->setupEventStoreWith(new PostgresSingleStreamStrategy(), 10000, $this->eventStreamsTable());
+
+        $streamEvent = UserCreated::with(
+            ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
+            1
+        );
+
+        $aggregateId = Uuid::uuid4()->toString();
+
+        $streamEvent = $streamEvent->withAddedMetadata('tag', 'person');
+        $streamEvent = $streamEvent->withAddedMetadata('_aggregate_id', $aggregateId);
+        $streamEvent = $streamEvent->withAddedMetadata('_aggregate_type', 'user');
+
+        $stream = new Stream(new StreamName('custom.Prooph\Model\User'), new \ArrayIterator([$streamEvent]));
+
+        $this->eventStore->create($stream);
+
+        $streamEvent = UsernameChanged::with(
+            ['name' => 'John Doe'],
+            1
+        );
+
+        $streamEvent = $streamEvent->withAddedMetadata('tag', 'person');
+        $streamEvent = $streamEvent->withAddedMetadata('_aggregate_id', $aggregateId);
+        $streamEvent = $streamEvent->withAddedMetadata('_aggregate_type', 'user');
+
+        $this->eventStore->appendTo(new StreamName('custom.Prooph\Model\User'), new \ArrayIterator([$streamEvent]));
+    }
+
+    public function it_ignores_transaction_handling_if_flag_is_enabled(): void
+    {
+        $connection = $this->prophesize(PDO::class);
+        $connection->beginTransaction()->shouldNotBeCalled();
+        $connection->commit()->shouldNotBeCalled();
+        $connection->rollback()->shouldNotBeCalled();
+
+        $eventStore = new PostgresEventStore(new FQCNMessageFactory(), $connection->reveal(), new PostgresAggregateStreamStrategy());
+
+        $eventStore->beginTransaction();
+        $eventStore->commit();
+
+        $eventStore->beginTransaction();
+        $eventStore->rollback();
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_stream_if_stream_table_hasnt_been_created(): void
+    {
+        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy->method('createSchema')->willReturn([
+<<<SQL
+DO $$
+BEGIN
+    RAISE EXCEPTION '';
+END $$;
+SQL
+        ]);
+        $strategy->method('generateTableName')->willReturn('_non_existing_table');
+
+        $this->setupEventStoreWith($strategy, 10000, $this->eventStreamsTable());
+
+        $stream = new Stream(new StreamName('custom.Prooph\Model\User'), new \ArrayIterator());
+
+        try {
+            $this->eventStore->create($stream);
+        } catch (RuntimeException $e) {
+        }
+
+        $this->assertFalse($this->eventStore->hasStream($stream->streamName()));
+    }
+}

--- a/tests/Projection/PdoEventStoreQueryCustomSchemaTest.php
+++ b/tests/Projection/PdoEventStoreQueryCustomSchemaTest.php
@@ -24,7 +24,7 @@ use ProophTest\EventStore\Mock\UsernameChanged;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractEventStoreQueryTest;
 
-abstract class PdoEventStoreQueryCustomTablesTest extends AbstractEventStoreQueryTest
+abstract class PdoEventStoreQueryCustomSchemaTest extends AbstractEventStoreQueryTest
 {
     /**
      * @var ProjectionManager
@@ -46,12 +46,22 @@ abstract class PdoEventStoreQueryCustomTablesTest extends AbstractEventStoreQuer
         TestUtil::tearDownDatabase();
     }
 
+    protected function eventStreamsTable(): string 
+    {
+        return 'custom.event_streams';
+    }
+
+    protected function projectionsTable(): string
+    {
+        return 'custom.event_projections';
+    }
+
     /**
      * @test
      */
     public function it_updates_state_using_when_and_persists_with_block_size(): void
     {
-        $this->prepareEventStream('user-123');
+        $this->prepareEventStream('custom.user-123');
 
         $testCase = $this;
 
@@ -61,13 +71,13 @@ abstract class PdoEventStoreQueryCustomTablesTest extends AbstractEventStoreQuer
             ->fromAll()
             ->when([
                 UserCreated::class => function ($state, Message $event) use ($testCase): array {
-                    $testCase->assertEquals('user-123', $this->streamName());
+                    $testCase->assertEquals('custom.user-123', $this->streamName());
                     $state['name'] = $event->payload()['name'];
 
                     return $state;
                 },
                 UsernameChanged::class => function ($state, Message $event) use ($testCase): array {
-                    $testCase->assertEquals('user-123', $this->streamName());
+                    $testCase->assertEquals('custom.user-123', $this->streamName());
                     $state['name'] = $event->payload()['name'];
 
                     if ($event->payload()['name'] === 'Sascha') {
@@ -113,15 +123,5 @@ abstract class PdoEventStoreQueryCustomTablesTest extends AbstractEventStoreQuer
         $connection = $this->prophesize(PDO::class);
 
         new PdoEventStoreQuery($eventStore->reveal(), $connection->reveal(), $this->eventStreamsTable());
-    }
-
-    protected function eventStreamsTable(): string 
-    {
-        return 'events/streams';
-    }
-
-    protected function projectionsTable(): string
-    {
-        return 'events/projections';
     }
 }

--- a/tests/Projection/PdoEventStoreReadModelProjectorCustomSchemaTest.php
+++ b/tests/Projection/PdoEventStoreReadModelProjectorCustomSchemaTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo\Projection;
+
+use ArrayIterator;
+use PDO;
+use Prooph\Common\Messaging\Message;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\EventStoreDecorator;
+use Prooph\EventStore\Exception\InvalidArgumentException;
+use Prooph\EventStore\Pdo\Projection\PdoEventStoreReadModelProjector;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Prooph\EventStore\Projection\ReadModel;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+use ProophTest\EventStore\Mock\ReadModelMock;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Mock\UsernameChanged;
+use ProophTest\EventStore\Pdo\TestUtil;
+use ProophTest\EventStore\Projection\AbstractEventStoreReadModelProjectorTest;
+
+abstract class PdoEventStoreReadModelProjectorCustomSchemaTest extends AbstractEventStoreReadModelProjectorTest
+{
+    /**
+     * @var ProjectionManager
+     */
+    protected $projectionManager;
+
+    /**
+     * @var EventStore
+     */
+    protected $eventStore;
+
+    /**
+     * @var PDO
+     */
+    protected $connection;
+
+    protected function tearDown(): void
+    {
+        TestUtil::tearDownDatabase();
+    }
+
+    protected function eventStreamsTable(): string 
+    {
+        return 'custom.event_streams';
+    }
+
+    protected function projectionsTable(): string
+    {
+        return 'custom.event_projections';
+    }
+
+    protected function prepareEventStream(string $name): void
+    {
+        $events = [];
+        $events[] = UserCreated::with([
+            'name' => 'Alex',
+        ], 1);
+        for ($i = 2; $i < 50; $i++) {
+            $events[] = UsernameChanged::with([
+                'name' => uniqid('name_'),
+            ], $i);
+        }
+        $events[] = UsernameChanged::with([
+            'name' => 'Sascha',
+        ], 50);
+
+        $this->eventStore->create(new Stream(new StreamName($name), new ArrayIterator($events)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_read_model_using_when_and_loads_and_continues_again(): void
+    {
+        $this->prepareEventStream('custom.user-123');
+
+        $readModel = new ReadModelMock();
+
+        $projection = $this->projectionManager->createReadModelProjection('test_projection', $readModel);
+
+        $projection
+            ->fromAll()
+            ->when([
+                UserCreated::class => function ($state, Message $event): void {
+                    $this->readModel()->stack('insert', 'name', $event->payload()['name']);
+                },
+                UsernameChanged::class => function ($state, Message $event): void {
+                    $this->readModel()->stack('update', 'name', $event->payload()['name']);
+
+                    if ($event->metadata()['_aggregate_version'] === 50) {
+                        $this->stop();
+                    }
+                },
+            ])
+            ->run();
+
+        $this->assertEquals('Sascha', $readModel->read('name'));
+
+        $events = [];
+        for ($i = 51; $i < 100; $i++) {
+            $events[] = UsernameChanged::with([
+                'name' => uniqid('name_'),
+            ], $i);
+        }
+        $events[] = UsernameChanged::with([
+            'name' => 'Oliver',
+        ], 100);
+
+        $this->eventStore->appendTo(new StreamName('custom.user-123'), new ArrayIterator($events));
+
+        $projection = $this->projectionManager->createReadModelProjection('test_projection', $readModel);
+
+        $projection
+            ->fromAll()
+            ->when([
+                UserCreated::class => function ($state, Message $event): void {
+                    $this->readModel()->stack('insert', 'name', $event->payload()['name']);
+                },
+                UsernameChanged::class => function ($state, Message $event): void {
+                    $this->readModel()->stack('update', 'name', $event->payload()['name']);
+
+                    if ($event->metadata()['_aggregate_version'] === 100) {
+                        $this->stop();
+                    }
+                },
+            ])
+            ->run();
+
+        $this->assertEquals('Oliver', $readModel->read('name'));
+
+        $projection->reset();
+
+        $this->assertFalse($readModel->hasKey('name'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
+        $wrappedEventStore->getInnerEventStore()->willReturn($eventStore->reveal())->shouldBeCalled();
+
+        new PdoEventStoreReadModelProjector(
+            $wrappedEventStore->reveal(),
+            $this->connection,
+            'test_projection',
+            new ReadModelMock(),
+            $this->eventStreamsTable(),
+            $this->projectionsTable(),
+            1,
+            1,
+            1
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_unknown_event_store_instance_passed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event store instance given');
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $connection = $this->prophesize(PDO::class);
+        $readModel = $this->prophesize(ReadModel::class);
+
+        new PdoEventStoreReadModelProjector(
+            $eventStore->reveal(),
+            $connection->reveal(),
+            'test_projection',
+            $readModel->reveal(),
+            $this->eventStreamsTable(),
+            $this->projectionsTable(),
+            10,
+            10,
+            10
+        );
+    }
+}

--- a/tests/Projection/PostgresEventStoreProjectorCustomSchemaTest.php
+++ b/tests/Projection/PostgresEventStoreProjectorCustomSchemaTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo\Projection;
+
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Pdo\TestUtil;
+
+/**
+ * @group postgres
+ */
+class PostgresEventStoreProjectorCustomSchemaTest extends PdoEventStoreProjectorCustomSchemaTest
+{
+    use PostgresHelper;
+
+    protected function setUp(): void
+    {
+        if (TestUtil::getDatabaseDriver() !== 'pdo_pgsql') {
+            throw new \RuntimeException('Invalid database vendor');
+        }
+
+        $this->connection = TestUtil::getConnection();
+        TestUtil::initCustomSchemaDatabaseTables($this->connection);
+
+        $this->eventStore = new PostgresEventStore(
+            new FQCNMessageFactory(),
+            TestUtil::getConnection(),
+            new PostgresSimpleStreamStrategy(),
+            10000,
+            $this->eventStreamsTable()
+        );
+
+        $this->projectionManager = new PostgresProjectionManager(
+            $this->eventStore,
+            $this->connection,
+            $this->eventStreamsTable(),
+            $this->projectionsTable()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_missing_projection_table(): void
+    {
+        $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
+        $this->expectExceptionMessage("Error 42P01. Maybe the projection table is not setup?\nError-Info: ERROR:  relation \"{$this->projectionsTable()}\" does not exist\nLINE 1: SELECT status FROM");
+
+        $this->prepareEventStream('custom.user-123');
+
+        $this->connection->exec("DROP TABLE {$this->quoteIdent($this->projectionsTable())};");
+
+        $projection = $this->projectionManager->createProjection('test_projection');
+
+        $projection
+            ->fromStream('custom.user-123')
+            ->when([
+                UserCreated::class => function (array $state, UserCreated $event): array {
+                    $this->stop();
+
+                    return $state;
+                },
+            ])
+            ->run();
+    }
+}

--- a/tests/Projection/PostgresEventStoreQueryCustomSchemaTest.php
+++ b/tests/Projection/PostgresEventStoreQueryCustomSchemaTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo\Projection;
+
+use PDO;
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
+use ProophTest\EventStore\Pdo\TestUtil;
+
+/**
+ * @group postgres
+ */
+class PostgresEventStoreQueryCustomSchemaTest extends PdoEventStoreQueryCustomSchemaTest
+{
+    protected function setUp(): void
+    {
+        if (TestUtil::getDatabaseDriver() !== 'pdo_pgsql') {
+            throw new \RuntimeException('Invalid database vendor');
+        }
+
+        $this->connection = TestUtil::getConnection();
+        TestUtil::initCustomSchemaDatabaseTables($this->connection);
+
+        $this->eventStore = new PostgresEventStore(
+            new FQCNMessageFactory(),
+            TestUtil::getConnection(),
+            new PostgresSimpleStreamStrategy(),
+            10000,
+            $this->eventStreamsTable()
+
+        );
+
+        $this->projectionManager = new PostgresProjectionManager(
+            $this->eventStore,
+            $this->connection,
+            $this->eventStreamsTable(),
+            $this->projectionsTable()
+        );
+    }
+}

--- a/tests/Projection/PostgresEventStoreReadModelProjectorCustomSchemaTest.php
+++ b/tests/Projection/PostgresEventStoreReadModelProjectorCustomSchemaTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo\Projection;
+
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
+use ProophTest\EventStore\Mock\ReadModelMock;
+use ProophTest\EventStore\Mock\UserCreated;
+use ProophTest\EventStore\Pdo\TestUtil;
+
+/**
+ * @group postgres
+ */
+class PostgresEventStoreReadModelProjectorCustomSchemaTest extends PdoEventStoreReadModelProjectorCustomSchemaTest
+{
+    use PostgresHelper;
+
+    protected function setUp(): void
+    {
+        if (TestUtil::getDatabaseDriver() !== 'pdo_pgsql') {
+            throw new \RuntimeException('Invalid database vendor');
+        }
+
+        $this->connection = TestUtil::getConnection();
+        TestUtil::initCustomSchemaDatabaseTables($this->connection);
+
+        $this->eventStore = new PostgresEventStore(
+            new FQCNMessageFactory(),
+            TestUtil::getConnection(),
+            new PostgresSimpleStreamStrategy(),
+            10000,
+            $this->eventStreamsTable()
+
+        );
+
+        $this->projectionManager = new PostgresProjectionManager(
+            $this->eventStore,
+            $this->connection,
+            $this->eventStreamsTable(),
+            $this->projectionsTable()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_missing_projection_table(): void
+    {
+        $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
+        $this->expectExceptionMessage("Error 42P01. Maybe the projection table is not setup?\nError-Info: ERROR:  relation \"{$this->projectionsTable()}\" does not exist\nLINE 1: SELECT status FROM");
+
+        $this->prepareEventStream('custom.user-123');
+
+        $this->connection->exec("DROP TABLE {$this->quoteIdent($this->projectionsTable())};");
+
+        $projection = $this->projectionManager->createReadModelProjection('test_projection', new ReadModelMock());
+
+        $projection
+            ->fromStream('custom.user-123')
+            ->when([
+                UserCreated::class => function (array $state, UserCreated $event): array {
+                    $this->stop();
+
+                    return $state;
+                },
+            ])
+            ->run();
+    }
+}

--- a/tests/Projection/PostgresProjectionManagerCustomSchemaTest.php
+++ b/tests/Projection/PostgresProjectionManagerCustomSchemaTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-event-store.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Pdo\Projection;
+
+use PDO;
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\EventStoreDecorator;
+use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
+use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
+use Prooph\EventStore\Pdo\Util\PostgresHelper;
+use Prooph\EventStore\Projection\InMemoryProjectionManager;
+use ProophTest\EventStore\Pdo\TestUtil;
+use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
+
+/**
+ * @group postgres
+ */
+class PostgresProjectionManagerCustomSchemaTest extends AbstractProjectionManagerTest
+{
+    use PostgresHelper;
+    /**
+     * @var PostgresProjectionManager
+     */
+    protected $projectionManager;
+
+    /**
+     * @var PostgresEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var PDO
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        if (TestUtil::getDatabaseDriver() !== 'pdo_pgsql') {
+            throw new \RuntimeException('Invalid database vendor');
+        }
+
+        $this->connection = TestUtil::getConnection();
+        TestUtil::initCustomSchemaDatabaseTables($this->connection);
+
+        $this->eventStore = new PostgresEventStore(
+            new FQCNMessageFactory(),
+            $this->connection,
+            new PostgresAggregateStreamStrategy(),
+            10000,
+            $this->eventStreamsTable()
+
+        );
+        $this->projectionManager = new PostgresProjectionManager(
+            $this->eventStore,
+            $this->connection,
+            $this->eventStreamsTable(),
+            $this->projectionsTable()
+        );
+    }
+
+    protected function eventStreamsTable(): string 
+    {
+        return 'custom.event_streams';
+    }
+
+    protected function projectionsTable(): string
+    {
+        return 'custom.event_projections';
+    }
+
+    protected function tearDown(): void
+    {
+        TestUtil::tearDownDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_invalid_event_store_instance_passed(): void
+    {
+        $this->expectException(\Prooph\EventStore\Exception\InvalidArgumentException::class);
+
+        $eventStore = $this->prophesize(EventStore::class);
+
+        new InMemoryProjectionManager($eventStore->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_invalid_wrapped_event_store_instance_passed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $wrappedEventStore = $this->prophesize(EventStoreDecorator::class);
+        $wrappedEventStore->getInnerEventStore()->willReturn($eventStore->reveal())->shouldBeCalled();
+
+        new PostgresProjectionManager($wrappedEventStore->reveal(), $this->connection);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projecton_names_with_missing_db_table(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->connection->exec("DROP TABLE {$this->quoteIdent($this->projectionsTable())};");
+        $this->projectionManager->fetchProjectionNames(null, 200, 0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projection_names_using_invalid_regex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern given');
+
+        $this->projectionManager->fetchProjectionNamesRegex('invalid)', 10, 0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_fetching_projecton_names_regex_with_missing_db_table(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->connection->exec("DROP TABLE {$this->quoteIdent($this->projectionsTable())};");
+        $this->projectionManager->fetchProjectionNamesRegex('^foo', 200, 0);
+    }
+}

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -127,6 +127,14 @@ abstract class TestUtil
         $connection->exec(file_get_contents(__DIR__ . '/Assets/scripts/' . $vendor . '/02_projections_table.sql'));
     }
 
+    public static function initCustomSchemaDatabaseTables(PDO $connection): void
+    {
+        $vendor = self::getDatabaseVendor();
+
+        $connection->exec(file_get_contents(__DIR__ . '/Assets/scripts/' . $vendor . '/01_custom_event_streams_table.sql'));
+        $connection->exec(file_get_contents(__DIR__ . '/Assets/scripts/' . $vendor . '/02_custom_projections_table.sql'));
+    }
+
     public static function tearDownDatabase(): void
     {
         $connection = self::getConnection();
@@ -153,6 +161,8 @@ abstract class TestUtil
                     break;
             }
         }
+
+        $connection->exec('DROP SCHEMA IF EXISTS custom CASCADE');
     }
 
     public static function getProjectionLockedUntilFromDefaultProjectionsTable(PDO $connection, string $projectionName): ?\DateTimeImmutable


### PR DESCRIPTION
This pull request adds support of multi schema events stores and projection for PostresSQL implementation #157 .
Summary (only Pg related classes):
- Event streams  table and projections table name can be defined with custom DB schema.
- String before first dot in stream name treated as DB schema, so stream auto generated table will be created in custom schema.
I added additional tests to clarify the new behaviour