### PR TITLE
Add message to ConcurrencyException

### DIFF
--- a/src/Exception/ConcurrencyExceptionFactory.php
+++ b/src/Exception/ConcurrencyExceptionFactory.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Prooph\EventStore\Pdo\Exception;
+
+use Prooph\EventStore\Exception\ConcurrencyException;
+
+class ConcurrencyExceptionFactory
+{
+    public static function fromStatementErrorInfo(array $errorInfo): ConcurrencyException
+    {
+        return new ConcurrencyException(
+            sprintf(
+                "Some of the aggregate IDs or event IDs have already been used in the same stream. The PDO error should contain more information:\nError %s.\nError-Info: %s",
+                $errorInfo[0],
+                $errorInfo[2]
+            )
+        );
+    }
+}

--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -17,12 +17,12 @@ use Iterator;
 use PDO;
 use PDOException;
 use Prooph\Common\Messaging\MessageFactory;
-use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Metadata\FieldType;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Stream;
@@ -249,7 +249,7 @@ EOT;
                 $this->connection->rollBack();
             }
 
-            throw new ConcurrencyException();
+            throw ConcurrencyExceptionFactory::fromStatementErrorInfo($statement->errorInfo());
         }
 
         if ($statement->errorCode() !== '00000') {

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -17,12 +17,12 @@ use Iterator;
 use PDO;
 use PDOException;
 use Prooph\Common\Messaging\MessageFactory;
-use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Metadata\FieldType;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Stream;
@@ -249,7 +249,7 @@ EOT;
                 $this->connection->rollBack();
             }
 
-            throw new ConcurrencyException();
+            throw ConcurrencyExceptionFactory::fromStatementErrorInfo($statement->errorInfo());
         }
 
         if ($statement->errorCode() !== '00000') {

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -17,7 +17,6 @@ use Iterator;
 use PDO;
 use PDOException;
 use Prooph\Common\Messaging\MessageFactory;
-use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Exception\StreamExistsAlready;
 use Prooph\EventStore\Exception\StreamNotFound;
 use Prooph\EventStore\Exception\TransactionAlreadyStarted;
@@ -25,6 +24,7 @@ use Prooph\EventStore\Exception\TransactionNotStarted;
 use Prooph\EventStore\Metadata\FieldType;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\Util\PostgresHelper;
@@ -218,7 +218,7 @@ EOT;
         }
 
         if (in_array($statement->errorCode(), ['23000', '23505'], true)) {
-            throw new ConcurrencyException();
+            throw ConcurrencyExceptionFactory::fromStatementErrorInfo($statement->errorInfo());
         }
 
         if ($statement->errorCode() !== '00000') {


### PR DESCRIPTION
Closes #161.

I don't think we can easily detect if the problem was an aggregate ID or an event ID (not without an additional select to check for duplicates). However the information seems to be in PDO's ErrorInfo so I'd like to simply pass it along in the exception message.

This will of course require another PR for `ActionEventEmitterEventStore` to pass the message along [here](https://github.com/prooph/event-store/blob/master/src/ActionEventEmitterEventStore.php#L88-L89) instead of the boolean.

I'll send that PR later. Unless of course you're against this solution.