### PR TITLE
Double bracket typo

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -70,7 +70,7 @@ everyone likes (especially DB admins).
 
 All needed database tables will be created automatically for you.
 
-Note: For event-store projections the aggregate stream strategy is not that performant anymore, consider using [CategoryStreamProjectionRunner](https://github.com/prooph/standard-projections/blob/master/src/CategoryStreamProjectionRunner.php) from the [standard-projections]((https://github.com/prooph/standard-projections) repository.
+Note: For event-store projections the aggregate stream strategy is not that performant anymore, consider using [CategoryStreamProjectionRunner](https://github.com/prooph/standard-projections/blob/master/src/CategoryStreamProjectionRunner.php) from the [standard-projections](https://github.com/prooph/standard-projections) repository.
 But even than, the projections would be slow, because the projector needs to check all the streams one-by-one for any new events. Because of this speed of finding and projecting any new events depends on the number of streams which means it would rapidly decrease as you add more data to your event store.
 
 You could however drastically improve the projections, if you would add a category stream projection as event-store-plugin. (This doesn't exist, yet)


### PR DESCRIPTION
Typo that causes the link to not render as a link.