### PR TITLE
Removed usage of mariadb json_value with boolean

### DIFF
--- a/.travis.install-mariadb-10.2.14.sh
+++ b/.travis.install-mariadb-10.2.14.sh
@@ -1,5 +1,0 @@
-sudo apt-get install software-properties-common
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
-sudo add-apt-repository 'deb https://downloads.mariadb.com/MariaDB/mariadb-10.2.14/repo/ubuntu trusty main'
-sudo apt-get update -q
-sudo apt-get install -q -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" mariadb-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,34 @@ matrix:
         - DB=mariadb_10.2
         - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
     - php: 7.1
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES=""
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+      addons:
+        mariadb: '10.3'
+    - php: 7.1
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+      addons:
+        mariadb: '10.3'
+    - php: 7.1
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES=""
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+        - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
+      addons:
+        mariadb: '10.3'
+    - php: 7.1
       sudo: true
       env:
         - DEPENDENCIES=""
@@ -142,6 +170,34 @@ matrix:
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
         - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
+    - php: 7.2
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES=""
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+      addons:
+        mariadb: '10.3'
+    - php: 7.2
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+      addons:
+        mariadb: '10.3'
+    - php: 7.2
+      dist: trusty
+      sudo: true
+      env:
+        - DEPENDENCIES=""
+        - DRIVER="pdo_mysql"
+        - DB=mariadb_10.3
+        - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
+      addons:
+        mariadb: '10.3'
     - php: 7.2
       sudo: true
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
         - DEPENDENCIES=""
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
+      addons:
+          mariadb: '10.2'
     - php: 7.1
       dist: trusty
       sudo: true
@@ -19,6 +21,8 @@ matrix:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
+      addons:
+          mariadb: '10.2'
     - php: 7.1
       dist: trusty
       sudo: true
@@ -27,6 +31,8 @@ matrix:
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
         - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
+      addons:
+          mariadb: '10.2'
     - php: 7.1
       dist: trusty
       sudo: true
@@ -155,6 +161,8 @@ matrix:
         - DEPENDENCIES=""
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
+      addons:
+          mariadb: '10.2'
     - php: 7.2
       dist: trusty
       sudo: true
@@ -162,6 +170,8 @@ matrix:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
+      addons:
+          mariadb: '10.2'
     - php: 7.2
       dist: trusty
       sudo: true
@@ -170,6 +180,8 @@ matrix:
         - DRIVER="pdo_mysql"
         - DB=mariadb_10.2
         - DB_ATTR_ERRMODE=2 # \PDO::ERRMODE_EXCEPTION
+      addons:
+          mariadb: '10.2'
     - php: 7.2
       dist: trusty
       sudo: true
@@ -300,7 +312,6 @@ before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
   - phpenv config-rm xdebug.ini
   - VENDOR=$(echo $DB | cut -d'_' -f 1)
-  - if [[ $DB == 'mariadb_10.2' ]]; then bash .travis.install-mariadb-10.2.14.sh; fi
   - if [[ $DB == 'mysql_5.7' ]]; then bash .travis.install-mysql-5.7.sh; fi
   - if [[ $DRIVER == 'pdo_mysql' ]]; then  mysql -e 'create database event_store_tests;'; fi
   - if [[ $DRIVER == 'pdo_pgsql' ]]; then psql -c 'create database event_store_tests;' -U postgres; fi

--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -696,7 +696,7 @@ SQL;
 
             if ($fieldType->is(FieldType::METADATA())) {
                 if (\is_bool($value)) {
-                    $where[] = "json_value(metadata, '$.$field') $operatorString '" . \var_export($value, true) . "' $operatorStringEnd";
+                    $where[] = "json_extract(metadata, '$.$field') $operatorString " . ($value ? 1 : 0) . " $operatorStringEnd";
                     continue;
                 }
 


### PR DESCRIPTION
Prior to MariaDB 10.2.16, json_value would return the `true` or `false`
string when fetching a boolean json data. From 10.2.16, it returns the
`1` or `0` integer.

See https://jira.mariadb.org/browse/MDEV-15905
See https://github.com/prooph/pdo-event-store/issues/164

The solution provided here is to use `json_extract` which behavior hasn't changed (it always return `0` or `1` when fetching boolean json data).

--

Side Note: The testsuite passes with MariaDB 10.3.9 (locally), I could work on adding it to the travis build if that's something you'd be interested in @prolic @codeliner ?