### PR TITLE
Implement a second optional MetadataMatcher parameter for fromStream methods

### DIFF
--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -24,6 +24,7 @@ use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
+use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Pdo\Exception\ProjectionNotCreatedException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\PdoEventStore;
@@ -161,6 +162,11 @@ final class PdoEventStoreProjector implements Projector
      */
     private $lastLockUpdate;
 
+    /**
+     * @var MetadataMatcher|null
+     */
+    private $metadataMatcher;
+
     public function __construct(
         EventStore $eventStore,
         PDO $connection,
@@ -220,13 +226,14 @@ final class PdoEventStoreProjector implements Projector
         return $this;
     }
 
-    public function fromStream(string $streamName): Projector
+    public function fromStream(string $streamName, MetadataMatcher $metadataMatcher = null): Projector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
         }
 
         $this->query['streams'][] = $streamName;
+        $this->metadataMatcher = $metadataMatcher;
 
         return $this;
     }
@@ -504,7 +511,7 @@ EOT;
             do {
                 foreach ($this->streamPositions as $streamName => $position) {
                     try {
-                        $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
+                        $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1, null, $this->metadataMatcher);
                     } catch (Exception\StreamNotFound $e) {
                         // ignore
                         continue;

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -22,6 +22,7 @@ use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Exception;
+use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Pdo\Exception\ProjectionNotCreatedException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\PdoEventStore;
@@ -152,6 +153,11 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
      */
     private $lastLockUpdate;
 
+    /**
+     * @var MetadataMatcher|null
+     */
+    private $metadataMatcher;
+
     public function __construct(
         EventStore $eventStore,
         PDO $connection,
@@ -210,13 +216,14 @@ final class PdoEventStoreReadModelProjector implements ReadModelProjector
         return $this;
     }
 
-    public function fromStream(string $streamName): ReadModelProjector
+    public function fromStream(string $streamName, MetadataMatcher $metadataMatcher = null): ReadModelProjector
     {
         if (null !== $this->query) {
             throw new Exception\RuntimeException('From was already called');
         }
 
         $this->query['streams'][] = $streamName;
+        $this->metadataMatcher = $metadataMatcher;
 
         return $this;
     }
@@ -467,7 +474,7 @@ EOT;
             do {
                 foreach ($this->streamPositions as $streamName => $position) {
                     try {
-                        $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1);
+                        $streamEvents = $this->eventStore->load(new StreamName($streamName), $position + 1, null, $this->metadataMatcher);
                     } catch (Exception\StreamNotFound $e) {
                         // ignore
                         continue;


### PR DESCRIPTION
Implementation a second optional parameter for fromStream Methods. So its possible to filter Streams for Projections, Queries and so on. As example is it possible to filter for an AggregationID to create Projections for a single Aggregate with the SingleStream- or SimpleStreamStrategy
- related to: https://github.com/prooph/event-store/pull/350