### PR TITLE
Remove forced index from MySqlSingleStreamStrategy

### DIFF
--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -16,12 +16,11 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
-use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHint
+final class MySqlSingleStreamStrategy implements PersistenceStrategy
 {
     /**
      * @var MessageConverter
@@ -91,10 +90,5 @@ EOT;
     public function generateTableName(StreamName $streamName): string
     {
         return '_' . \sha1($streamName->toString());
-    }
-
-    public function indexName(): string
-    {
-        return 'ix_query_aggregate';
     }
 }


### PR DESCRIPTION
When loading the event stream from a projector, it currently forces MySQL to use the index `ix_query_aggregate`, which contains 3 fields, but in this case the primary key index is more efficient (see https://github.com/prooph/pdo-event-store/issues/142#issuecomment-380023812).

This is causing the DB to run an expensive "Creating sorting index" operation on every query:

![image](https://user-images.githubusercontent.com/1850941/54627731-c981a000-4a52-11e9-8af0-8f5ea891508d.png)

The change introduced by this PR reduced query time here by 99.7% (from 0.19646025 to 0.00045325 seconds) and reduced the overall CPU usage with 9 projections from 70% to 5% :P

![image](https://user-images.githubusercontent.com/1850941/54627837-fe8df280-4a52-11e9-96a1-8b2a1305a419.png)

Not sure what is the impact when loading events with `MetadataMatcher`, since I'm not reconstituting aggregates from history in my current project. But I guess it should automatically detect the most suited index. Anyway, here is the PR as suggested by @codeliner in gitter.