### PR TITLE
Fix reference error in PostgresEventStore for MetadataMatcher with IN Operations

### DIFF
--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -688,9 +688,9 @@ SQL;
             $parameters = [];
 
             if (\is_array($value)) {
-                foreach ($value as $k => &$v) {
+                foreach ($value as $k => $v) {
                     $parameters[] = ':metadata_' . $key . '_' . $k;
-                    $v = (string) $v;
+                    $value[$k] = (string) $v;
                 }
             } else {
                 $parameters = [':metadata_' . $key];


### PR DESCRIPTION
Fix reference error in PostgresEventStore for MetadataMatcher with IN Operations.

The removed value reference leads to wrong values for the IN operation.

Example:

```
(new MetadataMatcher())
	->withMetadataMatch(
	    'event_name',
	    Operator::IN(),
	    [
	        'Event-1',
	        'Event-2'
	    ],
	    FieldType::MESSAGE_PROPERTY()
	)
```

Results to:

```
$values = [
	'metadata_0_0' => 'Event-1',
	'metadata_0_1' => 'Event-1'
]
```

The Second values is replaced by the value reference with the first one.