### PR TITLE
Improvement/persist after blocksize processed events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,9 @@
     ],
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/basz/event-store.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
-        "prooph/event-store": "dev-improvement/persist-after-blocksize-processed-events as 7.5.2"
+        "prooph/event-store": "7.x-dev as 7.5.2"
     },
     "require-dev": {
         "sandrokeil/interop-config": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,15 @@
     ],
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/basz/event-store.git"
+        }
+    ],
     "require": {
         "php": "^7.1",
-        "prooph/event-store": "^7.5"
+        "prooph/event-store": "dev-improvement/persist-after-blocksize-processed-events as 7.5.2"
     },
     "require-dev": {
         "sandrokeil/interop-config": "^2.0.1",

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -622,16 +622,7 @@ EOT;
                 $this->state = $result;
             }
 
-            if ($this->eventCounter === $this->persistBlockSize) {
-                $this->persist();
-                $this->eventCounter = 0;
-
-                $this->status = $this->fetchRemoteStatus();
-
-                if (! $this->status->is(ProjectionStatus::RUNNING()) && ! $this->status->is(ProjectionStatus::IDLE())) {
-                    $this->isStopped = true;
-                }
-            }
+            $this->persistAndFetchRemoteStatusWhenBlockSizeThresholdReached();
 
             if ($this->isStopped) {
                 break;
@@ -650,11 +641,17 @@ EOT;
             /* @var Message $event */
             $this->streamPositions[$streamName] = $key;
 
+            $this->eventCounter++;
+
             if (! isset($this->handlers[$event->messageName()])) {
+                $this->persistAndFetchRemoteStatusWhenBlockSizeThresholdReached();
+
+                if ($this->isStopped) {
+                    break;
+                }
+
                 continue;
             }
-
-            $this->eventCounter++;
 
             $handler = $this->handlers[$event->messageName()];
             $result = $handler($this->state, $event);
@@ -663,19 +660,24 @@ EOT;
                 $this->state = $result;
             }
 
-            if ($this->eventCounter === $this->persistBlockSize) {
-                $this->persist();
-                $this->eventCounter = 0;
-
-                $this->status = $this->fetchRemoteStatus();
-
-                if (! $this->status->is(ProjectionStatus::RUNNING()) && ! $this->status->is(ProjectionStatus::IDLE())) {
-                    $this->isStopped = true;
-                }
-            }
+            $this->persistAndFetchRemoteStatusWhenBlockSizeThresholdReached();
 
             if ($this->isStopped) {
                 break;
+            }
+        }
+    }
+
+    private function persistAndFetchRemoteStatusWhenBlockSizeThresholdReached(): void
+    {
+        if ($this->eventCounter === $this->persistBlockSize) {
+            $this->persist();
+            $this->eventCounter = 0;
+
+            $this->status = $this->fetchRemoteStatus();
+
+            if (! $this->status->is(ProjectionStatus::RUNNING()) && ! $this->status->is(ProjectionStatus::IDLE())) {
+                $this->isStopped = true;
             }
         }
     }

--- a/src/Projection/PdoEventStoreQuery.php
+++ b/src/Projection/PdoEventStoreQuery.php
@@ -333,6 +333,10 @@ final class PdoEventStoreQuery implements Query
             $this->streamPositions[$streamName] = $key;
 
             if (! isset($this->handlers[$event->messageName()])) {
+                if ($this->isStopped) {
+                    break;
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
accompanies https://github.com/prooph/event-store/pull/368

what PR does is 

Persists the stream position when the number of *processed* events equals the blockSize threshold, not after *handled* events.

Potential harmful for process managers that handle a few event types in a stream. Currently a even projection with blockSize set to 1, it only records it's stream position after a handled events is processed.