### PR TITLE
Fixes projection lock string generation

### DIFF
--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -991,17 +991,8 @@ EOT;
 
     private function createLockUntilString(DateTimeImmutable $from): string
     {
-        $micros = (string) ((int) $from->format('u') + ($this->lockTimeoutMs * 1000));
-
-        $secs = \substr($micros, 0, -6);
-
-        if ('' === $secs) {
-            $secs = 0;
-        }
-
-        $resultMicros = \substr($micros, -6);
-
-        return $from->modify('+' . $secs .' seconds')->format('Y-m-d\TH:i:s') . '.' . $resultMicros;
+        $lockTimeoutMicros = $this->lockTimeoutMs * 1000;
+        return $from->modify("+ {$lockTimeoutMicros} microseconds")->format('Y-m-d\TH:i:s.u');
     }
 
     private function shouldUpdateLock(DateTimeImmutable $now): bool

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -991,8 +991,9 @@ EOT;
 
     private function createLockUntilString(DateTimeImmutable $from): string
     {
-        $lockTimeoutMicros = $this->lockTimeoutMs * 1000;
-        return $from->modify("+ {$lockTimeoutMicros} microseconds")->format('Y-m-d\TH:i:s.u');
+        $lockTimeoutMs = $this->lockTimeoutMs % 1000;
+        $lockTimeoutSeconds = ($this->lockTimeoutMs - $lockTimeoutMs) / 1000;
+        return $from->modify("+{$lockTimeoutSeconds} seconds +{$lockTimeoutMs} milliseconds")->format('Y-m-d\TH:i:s.u');
     }
 
     private function shouldUpdateLock(DateTimeImmutable $now): bool


### PR DESCRIPTION
closes #198

Since PHP 7.1 it's possible to manipulate DateTime instances microseconds, so
I was able to drop the old mechanism that did that manually