### PR TITLE
Change order of select and count statements to fix concurrency error

### DIFF
--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -353,8 +353,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -442,8 +442,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -353,8 +353,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -442,8 +442,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -301,8 +301,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -383,8 +383,8 @@ EOT;
         }
 
         try {
-            $selectStatement->execute();
             $countStatement->execute();
+            $selectStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }


### PR DESCRIPTION
When we make read and write operations with event store at the same time we can face one problem. Making select statement before count can bring us to situation where select statement return, for example, 10 rows and count statement, which will execute after select, return 15 records. It means that we change offset to 15 and lose 5 events.
So I think that we can change order of executing for this two statements and always have count less than select actual row count. This will help us go through as many lines as we get from the count statement. Diff in rows between count and select we can get from next request.