### PR TITLE
don't execute count statement on load

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
+        "ext-pdo": "*",
         "prooph/event-store": "^7.5.3"
     },
     "require-dev": {

--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -354,7 +354,6 @@ EOT;
 
         try {
             $selectStatement->execute();
-            $countStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -365,12 +364,6 @@ EOT;
 
         if ($selectStatement->errorCode() !== '00000') {
             throw StreamNotFound::with($streamName);
-        }
-
-        $counted = (int) $countStatement->fetchColumn();
-
-        if (0 === (null === $count ? $counted : \min($counted, $count))) {
-            return new EmptyStreamIterator();
         }
 
         return new PdoStreamIterator(

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -354,7 +354,6 @@ EOT;
 
         try {
             $selectStatement->execute();
-            $countStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -365,12 +364,6 @@ EOT;
 
         if ($selectStatement->errorCode() !== '00000') {
             throw StreamNotFound::with($streamName);
-        }
-
-        $counted = (int) $countStatement->fetchColumn();
-
-        if (0 === (null === $count ? $counted : \min($counted, $count))) {
-            return new EmptyStreamIterator();
         }
 
         return new PdoStreamIterator(

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -302,7 +302,6 @@ EOT;
 
         try {
             $selectStatement->execute();
-            $countStatement->execute();
         } catch (PDOException $exception) {
             // ignore and check error code
         }
@@ -313,12 +312,6 @@ EOT;
 
         if ($selectStatement->errorCode() !== '00000') {
             throw StreamNotFound::with($streamName);
-        }
-
-        $counted = (int) $countStatement->fetchColumn();
-
-        if (0 === (null === $count ? $counted : \min($counted, $count))) {
-            return new EmptyStreamIterator();
         }
 
         return new PdoStreamIterator(


### PR DESCRIPTION
superseeds https://github.com/prooph/pdo-event-store/pull/207

/cc @basz @fritz-gerneth @codeliner @unhappyby

The tests still pass, so this should work without making any BC. Please let me know what you think.