### PR TITLE
Add Schema-Creation to createSchema function

### DIFF
--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -57,10 +57,10 @@ CREATE TABLE $tableName (
 );
 EOT;
 
-        return [
+        return array_merge($this->getSchemaCreationSchema($tableName), [
             $statement,
             "CREATE UNIQUE INDEX on $tableName ((metadata->>'_aggregate_version'));",
-        ];
+        ]);
     }
 
     public function columnNames(): array
@@ -107,5 +107,17 @@ EOT;
         }
 
         return $table;
+    }
+
+    private function getSchemaCreationSchema(string $tableName) : array
+    {
+        if (!$schemaName = $this->extractSchema($tableName)) {
+            return [];
+        }
+
+        return [sprintf(
+            'CREATE SCHEMA IF NOT EXISTS %s',
+            $schemaName
+        )];
     }
 }

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -56,9 +56,9 @@ CREATE TABLE $tableName (
 );
 EOT;
 
-        return [
+        return array_merge($this->getSchemaCreationSchema($tableName), [
             $statement,
-        ];
+        ]);
     }
 
     public function columnNames(): array
@@ -99,5 +99,17 @@ EOT;
         }
 
         return $table;
+    }
+
+    private function getSchemaCreationSchema(string $tableName) : array
+    {
+        if (!$schemaName = $this->extractSchema($tableName)) {
+            return [];
+        }
+
+        return [sprintf(
+            'CREATE SCHEMA IF NOT EXISTS %s',
+            $schemaName
+        )];
     }
 }

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -69,11 +69,11 @@ CREATE INDEX ON $tableName
 ((metadata->>'_aggregate_type'), (metadata->>'_aggregate_id'), no);
 EOT;
 
-        return [
+        return array_merge($this->getSchemaCreationSchema($tableName), [
             $statement,
             $index1,
             $index2,
-        ];
+        ]);
     }
 
     public function columnNames(): array
@@ -114,5 +114,17 @@ EOT;
         }
 
         return $table;
+    }
+
+    private function getSchemaCreationSchema(string $tableName) : array
+    {
+        if (!$schemaName = $this->extractSchema($tableName)) {
+            return [];
+        }
+
+        return [sprintf(
+            'CREATE SCHEMA IF NOT EXISTS %s',
+            $schemaName
+        )];
     }
 }


### PR DESCRIPTION
Currently when a tableName with a dot is presented the name can correctly
be split up into schema and table name. But when the schema does not
exist the whole proces breaks as the table can not be created in a
non-existing space.

This commit adds an SQL-statement to the createSchema-function that – in
case a schema was given – will create the schema when it does not yet
exist.