### PR TITLE
Prevents using incompatible persistence strategy

### DIFF
--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -25,6 +25,7 @@ use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\WriteLockStrategy\NoLockStrategy;
 use Prooph\EventStore\Stream;
@@ -45,7 +46,7 @@ final class MariaDbEventStore implements PdoEventStore
     private $connection;
 
     /**
-     * @var PersistenceStrategy
+     * @var MariaDbPersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -80,7 +81,7 @@ final class MariaDbEventStore implements PdoEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        PersistenceStrategy $persistenceStrategy,
+        MariaDbPersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -25,6 +25,7 @@ use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\WriteLockStrategy\NoLockStrategy;
 use Prooph\EventStore\Stream;
@@ -45,7 +46,7 @@ final class MySqlEventStore implements PdoEventStore
     private $connection;
 
     /**
-     * @var PersistenceStrategy
+     * @var MySqlPersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -80,7 +81,7 @@ final class MySqlEventStore implements PdoEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        PersistenceStrategy $persistenceStrategy,
+        MySqlPersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,

--- a/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbAggregateStreamStrategy.php
@@ -18,11 +18,10 @@ use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MariaDbAggregateStreamStrategy implements PersistenceStrategy, MariaDBIndexedPersistenceStrategy
+final class MariaDbAggregateStreamStrategy implements MariaDbPersistenceStrategy, MariaDBIndexedPersistenceStrategy
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/MariaDbPersistenceStrategy.php
+++ b/src/PersistenceStrategy/MariaDbPersistenceStrategy.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2019 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2016-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\PersistenceStrategy;
+
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+
+interface MariaDbPersistenceStrategy extends PersistenceStrategy
+{
+}

--- a/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSimpleStreamStrategy.php
@@ -16,11 +16,10 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MariaDbSimpleStreamStrategy implements PersistenceStrategy
+final class MariaDbSimpleStreamStrategy implements MariaDbPersistenceStrategy
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MariaDbSingleStreamStrategy.php
@@ -18,11 +18,10 @@ use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MariaDbSingleStreamStrategy implements PersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
+final class MariaDbSingleStreamStrategy implements MariaDbPersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlAggregateStreamStrategy.php
@@ -17,11 +17,10 @@ use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MySqlAggregateStreamStrategy implements PersistenceStrategy
+final class MySqlAggregateStreamStrategy implements MySqlPersistenceStrategy
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/MySqlPersistenceStrategy.php
+++ b/src/PersistenceStrategy/MySqlPersistenceStrategy.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2019 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2016-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\PersistenceStrategy;
+
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+
+interface MySqlPersistenceStrategy extends PersistenceStrategy
+{
+}

--- a/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSimpleStreamStrategy.php
@@ -16,11 +16,10 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MySqlSimpleStreamStrategy implements PersistenceStrategy
+final class MySqlSimpleStreamStrategy implements MySqlPersistenceStrategy
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -17,11 +17,10 @@ use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHint
+final class MySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint
 {
     /**
      * @var MessageConverter

--- a/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresAggregateStreamStrategy.php
@@ -17,12 +17,11 @@ use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\Exception;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\StreamName;
 
-final class PostgresAggregateStreamStrategy implements PersistenceStrategy
+final class PostgresAggregateStreamStrategy implements PostgresPersistenceStrategy
 {
     use PostgresHelper;
 

--- a/src/PersistenceStrategy/PostgresPersistenceStrategy.php
+++ b/src/PersistenceStrategy/PostgresPersistenceStrategy.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2019 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2016-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\PersistenceStrategy;
+
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+
+interface PostgresPersistenceStrategy extends PersistenceStrategy
+{
+}

--- a/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSimpleStreamStrategy.php
@@ -16,12 +16,11 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\StreamName;
 
-final class PostgresSimpleStreamStrategy implements PersistenceStrategy
+final class PostgresSimpleStreamStrategy implements PostgresPersistenceStrategy
 {
     use PostgresHelper;
 

--- a/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/PostgresSingleStreamStrategy.php
@@ -16,12 +16,11 @@ namespace Prooph\EventStore\Pdo\PersistenceStrategy;
 use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\StreamName;
 
-final class PostgresSingleStreamStrategy implements PersistenceStrategy
+final class PostgresSingleStreamStrategy implements PostgresPersistenceStrategy
 {
     use PostgresHelper;
 

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -27,6 +27,7 @@ use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\ConcurrencyExceptionFactory;
 use Prooph\EventStore\Pdo\Exception\ExtensionNotLoaded;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\Pdo\Util\PostgresHelper;
 use Prooph\EventStore\Pdo\WriteLockStrategy\NoLockStrategy;
@@ -51,7 +52,7 @@ final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
     private $connection;
 
     /**
-     * @var PersistenceStrategy
+     * @var PostgresPersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -81,7 +82,7 @@ final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        PersistenceStrategy $persistenceStrategy,
+        PostgresPersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,

--- a/tests/Assets/PersistenceStrategy/CustomMariaDbAggregateStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomMariaDbAggregateStreamStrategy.php
@@ -16,11 +16,11 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 use Iterator;
 use Prooph\EventStore\Pdo\Exception;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomMariaDbAggregateStreamStrategy implements PersistenceStrategy, MariaDBIndexedPersistenceStrategy
+final class CustomMariaDbAggregateStreamStrategy implements MariaDbPersistenceStrategy, MariaDBIndexedPersistenceStrategy
 {
     /**
      * @param string $tableName

--- a/tests/Assets/PersistenceStrategy/CustomMariaDbSingleStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomMariaDbSingleStreamStrategy.php
@@ -16,11 +16,11 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 use Iterator;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomMariaDbSingleStreamStrategy implements PersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
+final class CustomMariaDbSingleStreamStrategy implements MariaDbPersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
 {
     /**
      * @param string $tableName

--- a/tests/Assets/PersistenceStrategy/CustomMySqlAggregateStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomMySqlAggregateStreamStrategy.php
@@ -15,11 +15,11 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 
 use Iterator;
 use Prooph\EventStore\Pdo\Exception;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomMySqlAggregateStreamStrategy implements PersistenceStrategy
+final class CustomMySqlAggregateStreamStrategy implements MySqlPersistenceStrategy
 {
     /**
      * @param string $tableName

--- a/tests/Assets/PersistenceStrategy/CustomMySqlSingleStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomMySqlSingleStreamStrategy.php
@@ -15,11 +15,11 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 
 use Iterator;
 use Prooph\EventStore\Pdo\HasQueryHint;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomMySqlSingleStreamStrategy implements PersistenceStrategy, HasQueryHint
+final class CustomMySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint
 {
     /**
      * @param string $tableName

--- a/tests/Assets/PersistenceStrategy/CustomPostgresAggregateStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomPostgresAggregateStreamStrategy.php
@@ -15,11 +15,11 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 
 use Iterator;
 use Prooph\EventStore\Pdo\Exception;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomPostgresAggregateStreamStrategy implements PersistenceStrategy
+final class CustomPostgresAggregateStreamStrategy implements PostgresPersistenceStrategy
 {
     /**
      * @param string $tableName

--- a/tests/Assets/PersistenceStrategy/CustomPostgresSingleStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomPostgresSingleStreamStrategy.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 
 use Iterator;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomPostgresSingleStreamStrategy implements PersistenceStrategy
+final class CustomPostgresSingleStreamStrategy implements PostgresPersistenceStrategy
 {
     /**
      * @param string $tableName

--- a/tests/Container/MariaDbEventStoreFactoryTest.php
+++ b/tests/Container/MariaDbEventStoreFactoryTest.php
@@ -51,7 +51,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new MariaDbEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -76,7 +76,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = MariaDbEventStoreFactory::$eventStoreName($container->reveal());
@@ -102,7 +102,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -136,7 +136,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -165,7 +165,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -197,7 +197,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MariaDbAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 
@@ -223,7 +223,7 @@ final class MariaDbEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory());
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class));
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MariaDbPersistenceStrategy::class));
         $container->get(MariaDbMetadataLockStrategy::class)->willReturn($this->prophesize(WriteLockStrategy::class))->shouldBeCalled();
 
         $factory = new MariaDbEventStoreFactory();

--- a/tests/Container/MariaDbProjectionManagerFactoryTest.php
+++ b/tests/Container/MariaDbProjectionManagerFactoryTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\Pdo\Container\MariaDbProjectionManagerFactory;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use Psr\Container\ContainerInterface;
@@ -42,7 +42,7 @@ class MariaDbProjectionManagerFactoryTest extends TestCase
         $connection = TestUtil::getConnection();
 
         $messageFactory = $this->prophesize(MessageFactory::class);
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class);
+        $persistenceStrategy = $this->prophesize(MariaDbPersistenceStrategy::class);
         $persistenceStrategy->willImplement(HasQueryHint::class);
 
         $container = $this->prophesize(ContainerInterface::class);
@@ -74,7 +74,7 @@ class MariaDbProjectionManagerFactoryTest extends TestCase
         $connection = TestUtil::getConnection();
 
         $messageFactory = $this->prophesize(MessageFactory::class);
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class);
+        $persistenceStrategy = $this->prophesize(MariaDbPersistenceStrategy::class);
         $persistenceStrategy->willImplement(HasQueryHint::class);
 
         $container = $this->prophesize(ContainerInterface::class);

--- a/tests/Container/MySqlEventStoreFactoryTest.php
+++ b/tests/Container/MySqlEventStoreFactoryTest.php
@@ -51,7 +51,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new MySqlEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -76,7 +76,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = MySqlEventStoreFactory::$eventStoreName($container->reveal());
@@ -102,7 +102,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -136,7 +136,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -165,7 +165,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -197,7 +197,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 
@@ -223,7 +223,7 @@ final class MySqlEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory());
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class));
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\MySqlPersistenceStrategy::class));
         $container->get(MysqlMetadataLockStrategy::class)->willReturn($this->prophesize(WriteLockStrategy::class))->shouldBeCalled();
 
         $factory = new MySqlEventStoreFactory();

--- a/tests/Container/MySqlProjectionManagerFactoryTest.php
+++ b/tests/Container/MySqlProjectionManagerFactoryTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\Pdo\Container\MySqlProjectionManagerFactory;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\HasQueryHint;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use Psr\Container\ContainerInterface;
@@ -42,7 +42,7 @@ class MySqlProjectionManagerFactoryTest extends TestCase
         $connection = TestUtil::getConnection();
 
         $messageFactory = $this->prophesize(MessageFactory::class);
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class);
+        $persistenceStrategy = $this->prophesize(MySqlPersistenceStrategy::class);
         $persistenceStrategy->willImplement(HasQueryHint::class);
 
         $container = $this->prophesize(ContainerInterface::class);
@@ -74,7 +74,7 @@ class MySqlProjectionManagerFactoryTest extends TestCase
         $connection = TestUtil::getConnection();
 
         $messageFactory = $this->prophesize(MessageFactory::class);
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class);
+        $persistenceStrategy = $this->prophesize(MySqlPersistenceStrategy::class);
         $persistenceStrategy->willImplement(HasQueryHint::class);
 
         $container = $this->prophesize(ContainerInterface::class);

--- a/tests/Container/PostgresEventStoreFactoryTest.php
+++ b/tests/Container/PostgresEventStoreFactoryTest.php
@@ -52,7 +52,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $factory = new PostgresEventStoreFactory();
         $eventStore = $factory($container->reveal());
@@ -77,7 +77,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $eventStoreName = 'custom';
         $eventStore = PostgresEventStoreFactory::$eventStoreName($container->reveal());
@@ -103,7 +103,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $featureMock = $this->getMockForAbstractClass(Plugin::class);
         $featureMock->expects($this->once())->method('attachToEventStore');
@@ -137,7 +137,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('plugin')->willReturn('notAValidPlugin');
 
@@ -166,7 +166,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('metadata_enricher1')->willReturn($metadataEnricher1->reveal());
         $container->get('metadata_enricher2')->willReturn($metadataEnricher2->reveal());
@@ -198,7 +198,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('config')->willReturn($config);
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory())->shouldBeCalled();
-        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class))->shouldBeCalled();
+        $container->get(PersistenceStrategy\PostgresAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class))->shouldBeCalled();
 
         $container->get('foobar')->willReturn('foobar');
 
@@ -224,7 +224,7 @@ final class PostgresEventStoreFactoryTest extends TestCase
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container->get(FQCNMessageFactory::class)->willReturn(new FQCNMessageFactory());
-        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy::class));
+        $container->get(PersistenceStrategy\MySqlAggregateStreamStrategy::class)->willReturn($this->prophesize(PersistenceStrategy\PostgresPersistenceStrategy::class));
         $container->get(NoLockStrategy::class)->willReturn($this->prophesize(WriteLockStrategy::class))->shouldBeCalled();
 
         $factory = new PostgresEventStoreFactory();

--- a/tests/Container/PostgresProjectionManagerFactoryTest.php
+++ b/tests/Container/PostgresProjectionManagerFactoryTest.php
@@ -18,7 +18,7 @@ use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\Container\PostgresProjectionManagerFactory;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
@@ -44,7 +44,7 @@ class PostgresProjectionManagerFactoryTest extends TestCase
         $eventStore = new PostgresEventStore(
             $this->createMock(MessageFactory::class),
             TestUtil::getConnection(),
-            $this->createMock(PersistenceStrategy::class)
+            $this->createMock(PostgresPersistenceStrategy::class)
         );
 
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
@@ -72,7 +72,7 @@ class PostgresProjectionManagerFactoryTest extends TestCase
         $eventStore = new PostgresEventStore(
             $this->createMock(MessageFactory::class),
             TestUtil::getConnection(),
-            $this->createMock(PersistenceStrategy::class)
+            $this->createMock(PostgresPersistenceStrategy::class)
         );
 
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();

--- a/tests/MariaDbCustomStrategiesEventStoreTest.php
+++ b/tests/MariaDbCustomStrategiesEventStoreTest.php
@@ -21,7 +21,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventStore\Mock\UserCreated;
@@ -167,7 +167,7 @@ final class MariaDbCustomStrategiesEventStoreTest extends MariaDbEventStoreTest
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(MariaDbPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn(["SIGNAL SQLSTATE '45000';"]);
         $strategy->method('generateTableName')->willReturn('_non_existing_table');
 

--- a/tests/MariaDbEventStoreTest.php
+++ b/tests/MariaDbEventStoreTest.php
@@ -22,8 +22,8 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSingleStreamStrategy;
 use Prooph\EventStore\Pdo\WriteLockStrategy;
 use Prooph\EventStore\Pdo\WriteLockStrategy\MariaDbMetadataLockStrategy;
@@ -278,7 +278,7 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(MariaDbPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn(["SIGNAL SQLSTATE '45000';"]);
         $strategy->method('generateTableName')->willReturn('_non_existing_table');
 

--- a/tests/MySqlEventStoreTest.php
+++ b/tests/MySqlEventStoreTest.php
@@ -22,8 +22,8 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSingleStreamStrategy;
 use Prooph\EventStore\Pdo\WriteLockStrategy;
 use Prooph\EventStore\Pdo\WriteLockStrategy\MysqlMetadataLockStrategy;
@@ -298,7 +298,7 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(MySqlPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn(["SIGNAL SQLSTATE '45000';"]);
         $strategy->method('generateTableName')->willReturn('_non_existing_table');
 

--- a/tests/PostgresCustomSchemaEventStoreTest.php
+++ b/tests/PostgresCustomSchemaEventStoreTest.php
@@ -19,8 +19,8 @@ use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Stream;
@@ -164,7 +164,7 @@ class PostgresCustomSchemaEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(PostgresPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn([
 <<<SQL
 DO $$

--- a/tests/PostgresCustomStrategiesEventStoreTest.php
+++ b/tests/PostgresCustomStrategiesEventStoreTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
@@ -159,7 +159,7 @@ final class PostgresCustomStrategiesEventStoreTest extends PostgresEventStoreTes
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(PostgresPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn([
 <<<SQL
 DO $$

--- a/tests/PostgresEventStoreTest.php
+++ b/tests/PostgresEventStoreTest.php
@@ -21,8 +21,8 @@ use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\WriteLockStrategy;
@@ -233,7 +233,7 @@ class PostgresEventStoreTest extends AbstractPdoEventStoreTest
      */
     public function it_removes_stream_if_stream_table_hasnt_been_created(): void
     {
-        $strategy = $this->createMock(PersistenceStrategy::class);
+        $strategy = $this->createMock(PostgresPersistenceStrategy::class);
         $strategy->method('createSchema')->willReturn([
 <<<SQL
 DO $$

--- a/tests/Projection/MariaDbEventStoreProjectorCustomTablesTest.php
+++ b/tests/Projection/MariaDbEventStoreProjectorCustomTablesTest.php
@@ -57,7 +57,7 @@ class MariaDbEventStoreProjectorCustomTablesTest extends PdoEventStoreProjectorC
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.events/projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.events/projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MariaDbEventStoreProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreProjectorTest.php
@@ -53,7 +53,7 @@ class MariaDbEventStoreProjectorTest extends PdoEventStoreProjectorTest
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MariaDbEventStoreReadModelProjectorCustomTablesTest.php
+++ b/tests/Projection/MariaDbEventStoreReadModelProjectorCustomTablesTest.php
@@ -77,7 +77,7 @@ class MariaDbEventStoreReadModelProjectorCustomTablesTest extends PdoEventStoreR
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.events/projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.events/projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
@@ -73,7 +73,7 @@ class MariaDbEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProj
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MariaDbProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/MariaDbProjectionManagerCustomTablesTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -54,7 +54,7 @@ class MariaDbProjectionManagerCustomTablesTest extends AbstractProjectionManager
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(MariaDbPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),

--- a/tests/Projection/MariaDbProjectionManagerTest.php
+++ b/tests/Projection/MariaDbProjectionManagerTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -54,7 +54,7 @@ class MariaDbProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(MariaDbPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new MariaDbEventStore(
             new FQCNMessageFactory(),

--- a/tests/Projection/MySqlEventStoreProjectorCustomTablesTest.php
+++ b/tests/Projection/MySqlEventStoreProjectorCustomTablesTest.php
@@ -57,7 +57,7 @@ class MySqlEventStoreProjectorCustomTablesTest extends PdoEventStoreProjectorCus
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.events/projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.events/projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MySqlEventStoreProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreProjectorTest.php
@@ -54,7 +54,7 @@ class MySqlEventStoreProjectorTest extends PdoEventStoreProjectorTest
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MySqlEventStoreReadModelProjectorCustomTablesTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectorCustomTablesTest.php
@@ -76,7 +76,7 @@ class MySqlEventStoreReadModelProjectorCustomTablesTest extends PdoEventStoreRea
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.events/projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.events/projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
@@ -73,7 +73,7 @@ class MySqlEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProjec
     public function it_handles_missing_projection_table(): void
     {
         $this->expectException(\Prooph\EventStore\Pdo\Exception\RuntimeException::class);
-        $this->expectExceptionMessage("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table 'event_store_tests.projections' doesn't exist");
+        $this->expectExceptionMessage(\sprintf("Error 42S02. Maybe the projection table is not setup?\nError-Info: Table '%s.projections' doesn't exist", \getenv('DB_NAME')));
 
         $this->prepareEventStream('user-123');
 

--- a/tests/Projection/MySqlProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/MySqlProjectionManagerCustomTablesTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -54,7 +54,7 @@ class MySqlProjectionManagerCustomTablesTest extends AbstractProjectionManagerTe
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(MySqlPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),

--- a/tests/Projection/MySqlProjectionManagerTest.php
+++ b/tests/Projection/MySqlProjectionManagerTest.php
@@ -20,7 +20,7 @@ use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
 use ProophTest\EventStore\Pdo\TestUtil;
 use ProophTest\EventStore\Projection\AbstractProjectionManagerTest;
@@ -54,7 +54,7 @@ class MySqlProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(MySqlPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new MySqlEventStore(
             new FQCNMessageFactory(),

--- a/tests/Projection/PostgresProjectionManagerCustomTablesTest.php
+++ b/tests/Projection/PostgresProjectionManagerCustomTablesTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
@@ -55,7 +55,7 @@ class PostgresProjectionManagerCustomTablesTest extends AbstractProjectionManage
         $this->connection = TestUtil::getConnection();
         TestUtil::initCustomDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(PostgresPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),

--- a/tests/Projection/PostgresProjectionManagerTest.php
+++ b/tests/Projection/PostgresProjectionManagerTest.php
@@ -19,7 +19,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\EventStoreDecorator;
 use Prooph\EventStore\Pdo\Exception\InvalidArgumentException;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
-use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
@@ -55,7 +55,7 @@ class PostgresProjectionManagerTest extends AbstractProjectionManagerTest
         $this->connection = TestUtil::getConnection();
         TestUtil::initDefaultDatabaseTables($this->connection);
 
-        $persistenceStrategy = $this->prophesize(PersistenceStrategy::class)->reveal();
+        $persistenceStrategy = $this->prophesize(PostgresPersistenceStrategy::class)->reveal();
 
         $this->eventStore = new PostgresEventStore(
             new FQCNMessageFactory(),


### PR DESCRIPTION
Currently, configuring a MariaDB PersistenceStrategy within a PostgresEventStore will not trigger PHP type check.
The result will most likely be the db server complaining about a wrong syntax (in the best case).

This PR prevents mixing persistence strategies and event store implementations.

Note: Not sure if this is compatible with php <7.4