### PR TITLE
Add gap detection to projections

### DIFF
--- a/src/Projection/GapDetection.php
+++ b/src/Projection/GapDetection.php
@@ -37,7 +37,8 @@ final class GapDetection
     private $retryConfig = [
         0, // First retry is triggered immediately
         5, // Second retry is triggered after 5ms
-        50, // Either DB is really busy or we have a real gap, wait another 50ms and run a last try
+        50, // Third retry with much longer sleep time
+        500, // Either DB is really busy or we have a real gap, wait another 500ms and run a last try
         // Add more ms values if projection should perform more retries
     ];
 

--- a/src/Projection/GapDetection.php
+++ b/src/Projection/GapDetection.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2020 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2016-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\Projection;
+
+use Prooph\Common\Messaging\Message;
+
+/**
+ * Class GapDetection
+ *
+ * In high load scenarios it is possible that projections skip events due to newer events becoming visible before old ones.
+ * For details you can take a look at this issue: https://github.com/prooph/pdo-event-store/issues/189
+ *
+ * The GapDetection class helps projectors to detect gaps while processing events and coordinates retries to fill gaps.
+ *
+ * @package Prooph\EventStore\Pdo\Projection
+ */
+final class GapDetection
+{
+    /**
+     * If gap still exists after all retries, projector moves on
+     *
+     * You can set your own sleep times. Each number is the sleep time in milliseconds before the next retry is performed
+     *
+     * @var array
+     */
+    private $retryConfig = [
+        0, // First retry is triggered immediately
+        5, // Second retry is triggered after 5ms
+        50, // Either DB is really busy or we have a real gap, wait another 50ms and run a last try
+        // Add more ms values if projection should perform more retries
+    ];
+
+    /**
+     * There are two reasons for gaps in event streams:
+     *
+     * 1. A transaction rollback caused a gap
+     * 2. Transaction visibility problem described in https://github.com/prooph/pdo-event-store/issues/189
+     *
+     * The latter can only occur if a projection processes events near realtime.
+     * The detection window ensures that during a projection replay gap retries are not performed. During replays
+     * only gaps caused by transaction rollbacks are possible. Retries would just waste a lot of time and resources.
+     *
+     * By default the window is set to 30 seconds, meaning only if the current processed event was recorded in the last
+     * 30 seconds gap detection will tell the projector to perform a retry.
+     *
+     * @var \DateInterval
+     */
+    private $detectionWindow;
+
+    /**
+     * @var int
+     */
+    private $retries = 0;
+
+    public function __construct(array $retryConfig = null, \DateInterval $detectionWindow = null)
+    {
+        if ($retryConfig) {
+            $this->retryConfig = $retryConfig;
+        }
+
+        if ($detectionWindow) {
+            $this->detectionWindow = $detectionWindow;
+        } else {
+            $this->detectionWindow = new \DateInterval('PT30S');
+        }
+    }
+
+    public function isRetrying(): bool
+    {
+        return $this->retries > 0;
+    }
+
+    public function trackRetry(): void
+    {
+        $this->retries++;
+    }
+
+    public function resetRetries(): void
+    {
+        $this->retries = 0;
+    }
+
+    public function getSleepForNextRetry(): int
+    {
+        return (int) $this->retryConfig[$this->retries] ?? 0;
+    }
+
+    public function isGapInStreamPosition(int $streamPosition, int $eventPosition): bool
+    {
+        return $streamPosition + 1 !== $eventPosition;
+    }
+
+    public function shouldRetryToFillGap(\DateTimeImmutable $now, Message $currentMessage): bool
+    {
+        //Only retry if message was written to stream in last 30s, otherwise it's a gap caused by a transaction rollback
+        //This check avoids unnecessary retries when replaying projections
+        if ($now->sub($this->detectionWindow) > $currentMessage->createdAt()) {
+            return false;
+        }
+
+        return \array_key_exists($this->retries, $this->retryConfig);
+    }
+}

--- a/src/Projection/MariaDbProjectionManager.php
+++ b/src/Projection/MariaDbProjectionManager.php
@@ -95,7 +95,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 
@@ -115,7 +116,8 @@ final class MariaDbProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreReadModelProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 

--- a/src/Projection/MySqlProjectionManager.php
+++ b/src/Projection/MySqlProjectionManager.php
@@ -96,7 +96,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 
@@ -116,7 +117,8 @@ final class MySqlProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreReadModelProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -172,7 +172,7 @@ final class PdoEventStoreProjector implements Projector
     private $metadataMatcher;
 
     /**
-     * @var GapDetection/null
+     * @var GapDetection|null
      */
     private $gapDetection;
 

--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -39,6 +39,8 @@ use Prooph\EventStore\Util\ArrayCache;
 
 final class PdoEventStoreProjector implements Projector
 {
+    public const OPTION_GAP_DETECTION = 'gap_detection';
+
     use PostgresHelper {
         quoteIdent as pgQuoteIdent;
         extractSchema as pgExtractSchema;
@@ -169,6 +171,11 @@ final class PdoEventStoreProjector implements Projector
      */
     private $metadataMatcher;
 
+    /**
+     * @var GapDetection/null
+     */
+    private $gapDetection;
+
     public function __construct(
         EventStore $eventStore,
         PDO $connection,
@@ -180,7 +187,8 @@ final class PdoEventStoreProjector implements Projector
         int $persistBlockSize,
         int $sleep,
         bool $triggerPcntlSignalDispatch = false,
-        int $updateLockThreshold = 0
+        int $updateLockThreshold = 0,
+        GapDetection $gapDetection = null
     ) {
         if ($triggerPcntlSignalDispatch && ! \extension_loaded('pcntl')) {
             throw Exception\ExtensionNotLoadedException::withName('pcntl');
@@ -198,6 +206,7 @@ final class PdoEventStoreProjector implements Projector
         $this->status = ProjectionStatus::IDLE();
         $this->triggerPcntlSignalDispatch = $triggerPcntlSignalDispatch;
         $this->updateLockThreshold = $updateLockThreshold;
+        $this->gapDetection = $gapDetection;
         $this->vendor = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         while ($eventStore instanceof EventStoreDecorator) {
@@ -526,16 +535,26 @@ EOT;
                 $streamEvents = new MergedStreamIterator(\array_keys($eventStreams), ...\array_values($eventStreams));
 
                 if ($singleHandler) {
-                    $this->handleStreamWithSingleHandler($streamEvents);
+                    $gapDetected = ! $this->handleStreamWithSingleHandler($streamEvents);
                 } else {
-                    $this->handleStreamWithHandlers($streamEvents);
+                    $gapDetected = ! $this->handleStreamWithHandlers($streamEvents);
                 }
 
-                if (0 === $this->eventCounter) {
-                    \usleep($this->sleep);
-                    $this->updateLock();
-                } else {
+                if ($gapDetected && $this->gapDetection) {
+                    $sleep = $this->gapDetection->getSleepForNextRetry();
+
+                    \usleep($sleep);
+                    $this->gapDetection->trackRetry();
                     $this->persist();
+                } else {
+                    $this->gapDetection && $this->gapDetection->resetRetries();
+
+                    if (0 === $this->eventCounter) {
+                        \usleep($this->sleep);
+                        $this->updateLock();
+                    } else {
+                        $this->persist();
+                    }
                 }
 
                 $this->eventCounter = 0;
@@ -603,7 +622,7 @@ EOT;
         return ProjectionStatus::byValue($result->status);
     }
 
-    private function handleStreamWithSingleHandler(MergedStreamIterator $events): void
+    private function handleStreamWithSingleHandler(MergedStreamIterator $events): bool
     {
         $handler = $this->handler;
 
@@ -614,6 +633,14 @@ EOT;
             }
 
             $this->currentStreamName = $events->streamName();
+
+            if ($this->gapDetection
+                && $this->gapDetection->isGapInStreamPosition((int) $this->streamPositions[$this->currentStreamName], (int) $key)
+                && $this->gapDetection->shouldRetryToFillGap(new \DateTimeImmutable('now', new DateTimeZone('UTC')), $event)
+            ) {
+                return false;
+            }
+
             $this->streamPositions[$this->currentStreamName] = $key;
             $this->eventCounter++;
 
@@ -629,9 +656,11 @@ EOT;
                 break;
             }
         }
+
+        return true;
     }
 
-    private function handleStreamWithHandlers(MergedStreamIterator $events): void
+    private function handleStreamWithHandlers(MergedStreamIterator $events): bool
     {
         /* @var Message $event */
         foreach ($events as $key => $event) {
@@ -640,6 +669,14 @@ EOT;
             }
 
             $this->currentStreamName = $events->streamName();
+
+            if ($this->gapDetection
+                && $this->gapDetection->isGapInStreamPosition((int) $this->streamPositions[$this->currentStreamName], (int) $key)
+                && $this->gapDetection->shouldRetryToFillGap(new \DateTimeImmutable('now', new DateTimeZone('UTC')), $event)
+            ) {
+                return false;
+            }
+
             $this->streamPositions[$this->currentStreamName] = $key;
 
             $this->eventCounter++;
@@ -667,6 +704,8 @@ EOT;
                 break;
             }
         }
+
+        return true;
     }
 
     private function persistAndFetchRemoteStatusWhenBlockSizeThresholdReached(): void

--- a/src/Projection/PostgresProjectionManager.php
+++ b/src/Projection/PostgresProjectionManager.php
@@ -98,7 +98,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreProjector::OPTION_SLEEP] ?? PdoEventStoreProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 
@@ -118,7 +119,8 @@ final class PostgresProjectionManager implements ProjectionManager
             $options[PdoEventStoreReadModelProjector::OPTION_PERSIST_BLOCK_SIZE] ?? PdoEventStoreReadModelProjector::DEFAULT_PERSIST_BLOCK_SIZE,
             $options[PdoEventStoreReadModelProjector::OPTION_SLEEP] ?? PdoEventStoreReadModelProjector::DEFAULT_SLEEP,
             $options[PdoEventStoreReadModelProjector::OPTION_PCNTL_DISPATCH] ?? PdoEventStoreReadModelProjector::DEFAULT_PCNTL_DISPATCH,
-            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD
+            $options[PdoEventStoreReadModelProjector::OPTION_UPDATE_LOCK_THRESHOLD] ?? PdoEventStoreReadModelProjector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            $options[PdoEventStoreReadModelProjector::OPTION_GAP_DETECTION] ?? null
         );
     }
 

--- a/tests/Projection/MariaDbEventStoreProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreProjectorTest.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -44,6 +46,18 @@ class MariaDbEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->projectionManager = new MariaDbProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new MariaDbEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MariaDbEventStoreReadModelProjectorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
@@ -47,6 +49,18 @@ class MariaDbEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProj
         $this->projectionManager = new MariaDbProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new MariaDbEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new MariaDbSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/Projection/MySqlEventStoreProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreProjectorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -45,6 +47,18 @@ class MySqlEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->projectionManager = new MySqlProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new MySqlEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/MySqlEventStoreReadModelProjectorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\MySqlEventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
@@ -47,6 +49,18 @@ class MySqlEventStoreReadModelProjectorTest extends PdoEventStoreReadModelProjec
         $this->projectionManager = new MySqlProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new MySqlEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new MySqlSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -535,4 +535,14 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
 
         $this->assertFalse($gapDetection->isRetrying());
     }
+
+    protected function prepareEventStreamWithOneEvent(string $name): void
+    {
+        $events = [];
+        $events[] = UserCreated::with([
+            'name' => 'Alex',
+        ], 1);
+
+        $this->eventStore->create(new Stream(new StreamName($name), new ArrayIterator($events)));
+    }
 }

--- a/tests/Projection/PdoEventStoreProjectorTest.php
+++ b/tests/Projection/PdoEventStoreProjectorTest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace ProophTest\EventStore\Pdo\Projection;
 
 use ArrayIterator;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
 use PDO;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -536,12 +539,156 @@ abstract class PdoEventStoreProjectorTest extends AbstractEventStoreProjectorTes
         $this->assertFalse($gapDetection->isRetrying());
     }
 
-    protected function prepareEventStreamWithOneEvent(string $name): void
+    /**
+     * @test
+     */
+    public function it_continues_when_retry_limit_is_reached_and_gap_not_filled()
+    {
+        $streamName = new StreamName('user');
+
+        $this->prepareEventStreamWithOneEvent($streamName->toString());
+
+        $parallelConnection = TestUtil::getConnection(false);
+        $secondEventStore = $this->setUpEventStoreWithControlledConnection($parallelConnection);
+
+        // Begin transaction and let it open
+        $parallelConnection->beginTransaction();
+
+        $secondEventStore->appendTo($streamName, new ArrayIterator([
+            UsernameChanged::with([
+                'name' => 'Bob',
+            ], 2),
+        ]));
+
+        // Insert third event, while parallel connection is still in transaction
+        $this->eventStore->appendTo($streamName, new ArrayIterator([
+            UsernameChanged::with([
+                'name' => 'Sascha',
+            ], 3),
+        ]));
+
+        //Two retries and an increased detection window to have enough time for the test to succeed
+        $gapDetection = new GapDetection([0, 5], new \DateInterval('PT60S'));
+
+        $projectionManager = $this->projectionManager;
+        $projection = $projectionManager->createProjection('test_projection', [
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 1,
+            PdoEventStoreProjector::OPTION_GAP_DETECTION => $gapDetection,
+        ]);
+
+        $projection
+            ->fromStream('user')
+            ->init(function () {
+                return [];
+            })
+            ->when([
+                UserCreated::class => function (array $state, Message $event): array {
+                    return $state;
+                },
+                UsernameChanged::class => function (array $state, Message $event): array {
+                    return $state;
+                },
+            ])
+            ->run(false);
+
+        $this->assertEquals(1, $projectionManager->fetchProjectionStreamPositions('test_projection')['user']);
+
+        $this->assertTrue($gapDetection->isRetrying());
+
+        // Force a real gap
+        $parallelConnection->rollBack();
+
+        // Run again with gap detection in retry mode
+        $projection->run(false);
+
+        // Projection should not move forward, but instead retry a second time
+        $this->assertEquals(1, $projectionManager->fetchProjectionStreamPositions('test_projection')['user']);
+
+        // Third run with gap detection still in retry mode, but limit reached
+        $projection->run(false);
+
+        //Projection should have moved forward
+        $this->assertEquals(3, $projectionManager->fetchProjectionStreamPositions('test_projection')['user']);
+
+        $this->assertFalse($gapDetection->isRetrying());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_perform_retry_when_event_is_older_than_detection_window()
+    {
+        $streamName = new StreamName('user');
+
+        // Simulate a projection replay by setting createdAt to yesterday
+        $timeOfRecording = (new \DateTimeImmutable('now', new DateTimeZone('UTC')))->sub(new DateInterval('P1D'));
+
+        $this->prepareEventStreamWithOneEvent($streamName->toString(), $timeOfRecording);
+
+        $parallelConnection = TestUtil::getConnection(false);
+        $secondEventStore = $this->setUpEventStoreWithControlledConnection($parallelConnection);
+
+        // Begin transaction and let it open
+        $parallelConnection->beginTransaction();
+
+        $secondEventStore->appendTo($streamName, new ArrayIterator([
+            UsernameChanged::withPayloadAndSpecifiedCreatedAt([
+                'name' => 'Bob',
+            ], 2, $timeOfRecording),
+        ]));
+
+        // Insert third event, while parallel connection is still in transaction
+        $this->eventStore->appendTo($streamName, new ArrayIterator([
+            UsernameChanged::withPayloadAndSpecifiedCreatedAt([
+                'name' => 'Sascha',
+            ], 3, $timeOfRecording),
+        ]));
+
+        //Two retries but detection window set to one minute only
+        $gapDetection = new GapDetection([0, 5], new \DateInterval('PT60S'));
+
+        $projectionManager = $this->projectionManager;
+        $projection = $projectionManager->createProjection('test_projection', [
+            Projector::OPTION_PERSIST_BLOCK_SIZE => 1,
+            PdoEventStoreProjector::OPTION_GAP_DETECTION => $gapDetection,
+        ]);
+
+        $projection
+            ->fromStream('user')
+            ->init(function () {
+                return [];
+            })
+            ->when([
+                UserCreated::class => function (array $state, Message $event): array {
+                    return $state;
+                },
+                UsernameChanged::class => function (array $state, Message $event): array {
+                    return $state;
+                },
+            ])
+            ->run(false);
+
+        // No retry, since gap is too old
+        $this->assertEquals(3, $projectionManager->fetchProjectionStreamPositions('test_projection')['user']);
+
+        $parallelConnection->rollBack();
+
+        $this->assertFalse($gapDetection->isRetrying());
+    }
+
+    protected function prepareEventStreamWithOneEvent(string $name, DateTimeImmutable $createdAt = null): void
     {
         $events = [];
-        $events[] = UserCreated::with([
-            'name' => 'Alex',
-        ], 1);
+
+        if ($createdAt) {
+            $events[] = UserCreated::withPayloadAndSpecifiedCreatedAt([
+                'name' => 'Alex',
+            ], 1, $createdAt);
+        } else {
+            $events[] = UserCreated::with([
+                'name' => 'Alex',
+            ], 1);
+        }
 
         $this->eventStore->create(new Stream(new StreamName($name), new ArrayIterator($events)));
     }

--- a/tests/Projection/PostgresEventStoreProjectorTest.php
+++ b/tests/Projection/PostgresEventStoreProjectorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -45,6 +47,18 @@ class PostgresEventStoreProjectorTest extends PdoEventStoreProjectorTest
         $this->projectionManager = new PostgresProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new PostgresEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/Projection/PostgresEventStoreReadModelProjectorTest.php
+++ b/tests/Projection/PostgresEventStoreReadModelProjectorTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Pdo\Projection;
 
+use PDO;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSimpleStreamStrategy;
 use Prooph\EventStore\Pdo\PostgresEventStore;
 use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
@@ -46,6 +48,18 @@ class PostgresEventStoreReadModelProjectorTest extends PdoEventStoreReadModelPro
         $this->projectionManager = new PostgresProjectionManager(
             $this->eventStore,
             $this->connection
+        );
+    }
+
+    protected function setUpEventStoreWithControlledConnection(PDO $connection): EventStore
+    {
+        return new PostgresEventStore(
+            new FQCNMessageFactory(),
+            $connection,
+            new PostgresSimpleStreamStrategy(new NoOpMessageConverter()),
+            10000,
+            'event_streams',
+            true
         );
     }
 

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -35,9 +35,9 @@ abstract class TestUtil
      */
     private static $connection;
 
-    public static function getConnection(): PDO
+    public static function getConnection($sharedConnection = true): PDO
     {
-        if (! isset(self::$connection)) {
+        if (! isset(self::$connection) || ! $sharedConnection) {
             $connectionParams = self::getConnectionParams();
             $separator = self::$driverSchemeSeparators[$connectionParams['driver']];
             $dsn = self::$driverSchemeAliases[$connectionParams['driver']] . ':';
@@ -46,6 +46,10 @@ abstract class TestUtil
             $dsn .= 'dbname=' . $connectionParams['dbname'] . $separator;
             $dsn .= self::getCharsetValue($connectionParams['charset'], $connectionParams['driver']) . $separator;
             $dsn = \rtrim($dsn);
+
+            if (! $sharedConnection) {
+                return new PDO($dsn, $connectionParams['user'], $connectionParams['password'], $connectionParams['options']);
+            }
 
             $retries = 10; // keep trying for 10 seconds, should be enough
             while (null === self::$connection && $retries > 0) {


### PR DESCRIPTION
Fixes https://github.com/prooph/pdo-event-store/issues/189

The PR adds a "gap detection" mechanism to projections. This means, that if the projection detects a gap in the stream position while processing events, it pauses processing for a configurable time, before rereading events from the last known position. 
Gap detection is disabled by default.

## Enabling gap detection for a projection:

```php
$gapDetection = new GapDetection();

$projection = $projectionManager->createProjection('test_projection', [
            PdoEventStoreProjector::OPTION_GAP_DETECTION => $gapDetection,
        ]);
``` 

## Enabling gap detection for a read model projection with custom configuration:

```php
$gapDetection = new GapDetection(
    // Configure retries in case a gap is detected
    [
        0, // First retry without any sleep time
        10, // Second retry after 10 ms
        30, // Wait another 30 ms before performing a third retry
    ],
    \DateInterval('PT60S') //Set detection window to 60s
);

$projection = $projectionManager->createReadModelProjection('test_projection', [
            PdoEventStoreReadModelProjector::OPTION_GAP_DETECTION => $gapDetection,
        ]);
``` 

### Detection window
If you set a detection window, gap detection is only performed on events not older than `NOW - window`
If the detection window is set to `PT60S`, only events created within the last 60 seconds are checked. Be careful when setting `Event::createdAt` manually (for example during a migration). 