### PR TITLE
Restores custom strategy backward compatibility

### DIFF
--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -46,7 +46,7 @@ final class MariaDbEventStore implements PdoEventStore
     private $connection;
 
     /**
-     * @var MariaDbPersistenceStrategy
+     * @var PersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -81,7 +81,7 @@ final class MariaDbEventStore implements PdoEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        MariaDbPersistenceStrategy $persistenceStrategy,
+        PersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,
@@ -93,6 +93,15 @@ final class MariaDbEventStore implements PdoEventStore
 
         if (null === $writeLockStrategy) {
             $writeLockStrategy = new NoLockStrategy();
+        }
+
+        if (! $persistenceStrategy instanceof MariaDbPersistenceStrategy) {
+            @\trigger_error(\sprintf(
+                '"%s" will expect an instance of "%s" from v2.0.0, please migrate your custom "%s" class.',
+                __CLASS__,
+                MariaDbPersistenceStrategy::class,
+                \get_class($persistenceStrategy)
+            ), E_USER_DEPRECATED);
         }
 
         Assertion::min($loadBatchSize, 1);

--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -46,7 +46,7 @@ final class MySqlEventStore implements PdoEventStore
     private $connection;
 
     /**
-     * @var MySqlPersistenceStrategy
+     * @var PersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -81,7 +81,7 @@ final class MySqlEventStore implements PdoEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        MySqlPersistenceStrategy $persistenceStrategy,
+        PersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,
@@ -89,6 +89,15 @@ final class MySqlEventStore implements PdoEventStore
     ) {
         if (! \extension_loaded('pdo_mysql')) {
             throw ExtensionNotLoaded::with('pdo_mysql');
+        }
+
+        if (! $persistenceStrategy instanceof MySqlPersistenceStrategy) {
+            @\trigger_error(\sprintf(
+                '"%s" will expect an instance of "%s" from v2.0.0, please migrate your custom "%s" class.',
+                __CLASS__,
+                MySqlPersistenceStrategy::class,
+                \get_class($persistenceStrategy)
+            ), E_USER_DEPRECATED);
         }
 
         if (null === $writeLockStrategy) {

--- a/src/PostgresEventStore.php
+++ b/src/PostgresEventStore.php
@@ -52,7 +52,7 @@ final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
     private $connection;
 
     /**
-     * @var PostgresPersistenceStrategy
+     * @var PersistenceStrategy
      */
     private $persistenceStrategy;
 
@@ -82,7 +82,7 @@ final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
     public function __construct(
         MessageFactory $messageFactory,
         PDO $connection,
-        PostgresPersistenceStrategy $persistenceStrategy,
+        PersistenceStrategy $persistenceStrategy,
         int $loadBatchSize = 10000,
         string $eventStreamsTable = 'event_streams',
         bool $disableTransactionHandling = false,
@@ -90,6 +90,15 @@ final class PostgresEventStore implements PdoEventStore, TransactionalEventStore
     ) {
         if (! \extension_loaded('pdo_pgsql')) {
             throw ExtensionNotLoaded::with('pdo_pgsql');
+        }
+
+        if (! $persistenceStrategy instanceof PostgresPersistenceStrategy) {
+            @\trigger_error(\sprintf(
+                '"%s" will expect an instance of "%s" from v2.0.0, please migrate your custom "%s" class.',
+                __CLASS__,
+                PostgresPersistenceStrategy::class,
+                \get_class($persistenceStrategy)
+            ), E_USER_DEPRECATED);
         }
 
         if (null === $writeLockStrategy) {

--- a/tests/MariaDbEventStoreTest.php
+++ b/tests/MariaDbEventStoreTest.php
@@ -22,6 +22,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MariaDbEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbAggregateStreamStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSingleStreamStrategy;
@@ -292,5 +293,22 @@ class MariaDbEventStoreTest extends AbstractPdoEventStoreTest
         }
 
         $this->assertFalse($this->eventStore->hasStream($stream->streamName()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_deprecation_error_when_non_vendor_specific_persistence_strategy_is_injected(): void
+    {
+        $deprecationRaised = false;
+
+        $handler = function () use (&$deprecationRaised) {
+            $deprecationRaised = true;
+        };
+        \set_error_handler($handler, E_USER_DEPRECATED);
+        $strategy = $this->createMock(PersistenceStrategy::class);
+        $this->setupEventStoreWith($strategy);
+        $this->assertTrue($deprecationRaised);
+        \restore_error_handler();
     }
 }

--- a/tests/MySqlEventStoreTest.php
+++ b/tests/MySqlEventStoreTest.php
@@ -22,6 +22,7 @@ use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Pdo\MySqlEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlAggregateStreamStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlSingleStreamStrategy;
@@ -312,5 +313,22 @@ class MySqlEventStoreTest extends AbstractPdoEventStoreTest
         }
 
         $this->assertFalse($this->eventStore->hasStream($stream->streamName()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_deprecation_error_when_non_vendor_specific_persistence_strategy_is_injected(): void
+    {
+        $deprecationRaised = false;
+
+        $handler = function () use (&$deprecationRaised) {
+            $deprecationRaised = true;
+        };
+        \set_error_handler($handler, E_USER_DEPRECATED);
+        $strategy = $this->createMock(PersistenceStrategy::class);
+        $this->setupEventStoreWith($strategy);
+        $this->assertTrue($deprecationRaised);
+        \restore_error_handler();
     }
 }

--- a/tests/PostgresEventStoreTest.php
+++ b/tests/PostgresEventStoreTest.php
@@ -21,6 +21,7 @@ use Prooph\EventStore\Exception\ConcurrencyException;
 use Prooph\EventStore\Metadata\MetadataMatcher;
 use Prooph\EventStore\Metadata\Operator;
 use Prooph\EventStore\Pdo\Exception\RuntimeException;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresAggregateStreamStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy;
@@ -254,5 +255,22 @@ SQL
         }
 
         $this->assertFalse($this->eventStore->hasStream($stream->streamName()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_triggers_deprecation_error_when_non_vendor_specific_persistence_strategy_is_injected(): void
+    {
+        $deprecationRaised = false;
+
+        $handler = function () use (&$deprecationRaised) {
+            $deprecationRaised = true;
+        };
+        \set_error_handler($handler, E_USER_DEPRECATED);
+        $strategy = $this->createMock(PersistenceStrategy::class);
+        $this->setupEventStoreWith($strategy);
+        $this->assertTrue($deprecationRaised);
+        \restore_error_handler();
     }
 }


### PR DESCRIPTION
This PR prevents a BC break introduced in https://github.com/prooph/pdo-event-store/pull/217 by reverting the event stores constructor signature.

It also triggers a deprecation error to prepare users to future BC break (in 2.0.0).