### PR TITLE
Fix docker compose setup for PostgreSQL

### DIFF
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -15,6 +15,7 @@ services:
     image: postgres:alpine
     environment:
       - POSTGRES_DB=event_store_tests
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   mariadb:
     image: mariadb:10.3


### PR DESCRIPTION
The current version of the PostgreSQL docker container requires a non-empty password to be set. The docker-compose log shows the following error:

> Error: Database is uninitialized and superuser password is not specified.
> postgres_1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
> postgres_1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
> postgres_1  |
> postgres_1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
> postgres_1  |        connections without a password. This is *not* recommended.

Despite the warning at the end, it is certainly appropriate to trust all connections for the test database.