### PR TITLE
Add indexed queries to MySqlEventStore

### DIFF
--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -721,6 +721,7 @@ SQL;
         }
 
         foreach ($metadataMatcher->data() as $key => $match) {
+            $this->convertToColumn($match);
             /** @var FieldType $fieldType */
             $fieldType = $match['fieldType'];
             $field = $match['field'];
@@ -863,6 +864,22 @@ EOT;
 
             if (! $result) {
                 throw new RuntimeException('Error during createSchemaFor: ' . \implode('; ', $statement->errorInfo()));
+            }
+        }
+    }
+
+    /**
+     * Convert metadata fields into indexed columns
+     *
+     * @example `_aggregate__id` => `aggregate_id`
+     */
+    private function convertToColumn(array &$match): void
+    {
+        if ($this->persistenceStrategy instanceof MySqlIndexedPersistenceStrategy) {
+            $indexedColumns = $this->persistenceStrategy->indexedMetadataFields();
+            if (\in_array($match['field'], \array_keys($indexedColumns), true)) {
+                $match['field'] = $indexedColumns[$match['field']];
+                $match['fieldType'] = FieldType::MESSAGE_PROPERTY();
             }
         }
     }

--- a/src/MySqlIndexedPersistenceStrategy.php
+++ b/src/MySqlIndexedPersistenceStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo;
+
+interface MySqlIndexedPersistenceStrategy
+{
+    /**
+     * Return an array of indexed columns to enable the use of indexes in MariaDB
+     *
+     * @example
+     *      [
+     *          '_aggregate_id' => 'aggregate_id',
+     *          '_aggregate_type' => 'aggregate_type',
+     *          '_aggregate_version' => 'aggregate_version',
+     *      ]
+     */
+    public function indexedMetadataFields(): array;
+}

--- a/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
+++ b/src/PersistenceStrategy/MySqlSingleStreamStrategy.php
@@ -17,10 +17,11 @@ use Iterator;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\Pdo\DefaultMessageConverter;
 use Prooph\EventStore\Pdo\HasQueryHint;
+use Prooph\EventStore\Pdo\MySqlIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class MySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint
+final class MySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint, MySqlIndexedPersistenceStrategy
 {
     /**
      * @var MessageConverter
@@ -67,6 +68,15 @@ EOT;
             'payload',
             'metadata',
             'created_at',
+        ];
+    }
+
+    public function indexedMetadataFields(): array
+    {
+        return [
+            '_aggregate_id' => 'aggregate_id',
+            '_aggregate_type' => 'aggregate_type',
+            '_aggregate_version' => 'aggregate_version',
         ];
     }
 

--- a/tests/Assets/PersistenceStrategy/CustomMySqlSingleStreamStrategy.php
+++ b/tests/Assets/PersistenceStrategy/CustomMySqlSingleStreamStrategy.php
@@ -15,11 +15,12 @@ namespace ProophTest\EventStore\Pdo\Assets\PersistenceStrategy;
 
 use Iterator;
 use Prooph\EventStore\Pdo\HasQueryHint;
+use Prooph\EventStore\Pdo\MySqlIndexedPersistenceStrategy;
 use Prooph\EventStore\Pdo\PersistenceStrategy\MySqlPersistenceStrategy;
 use Prooph\EventStore\Pdo\Util\Json;
 use Prooph\EventStore\StreamName;
 
-final class CustomMySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint
+final class CustomMySqlSingleStreamStrategy implements MySqlPersistenceStrategy, HasQueryHint, MySqlIndexedPersistenceStrategy
 {
     /**
      * @param string $tableName
@@ -56,6 +57,15 @@ EOT;
             'payload',
             'metadata',
             'created_at',
+        ];
+    }
+
+    public function indexedMetadataFields(): array
+    {
+        return [
+            '_aggregate_id' => 'aggregate_id',
+            '_aggregate_type' => 'aggregate_type',
+            '_aggregate_version' => 'aggregate_version',
         ];
     }
 


### PR DESCRIPTION
We recently noticed that the MySql event store does not actually use the index when loading events for an aggregate.

This PR copies the implementation from the Maria DB event store. Note that it does so only for the single stream strategy, as this is what we use.

We have been running this in production for several weeks now (patched on top of 1.10.5).
