### PR TITLE
free up memory from PDO statement before next run

### DIFF
--- a/src/Projection/PdoEventStoreProjector.php
+++ b/src/Projection/PdoEventStoreProjector.php
@@ -522,6 +522,7 @@ EOT;
         try {
             do {
                 $eventStreams = [];
+                $streamEvents = []; // free up memory from PDO statement
 
                 foreach ($this->streamPositions as $streamName => $position) {
                     try {

--- a/src/Projection/PdoEventStoreReadModelProjector.php
+++ b/src/Projection/PdoEventStoreReadModelProjector.php
@@ -485,6 +485,7 @@ EOT;
         try {
             do {
                 $eventStreams = [];
+                $streamEvents = []; // free up memory from PDO statement
 
                 foreach ($this->streamPositions as $streamName => $position) {
                     try {


### PR DESCRIPTION
This fixes a memory issue if you have large events or a large `loadBatchSize`. 

Assume you have a Docker service memory limit of 512 MB. The first run (`$selectStatement->execute();` in `\Prooph\EventStore\Pdo\PostgresEventStore::load`) consumes 320 MB of RAM because of big events and a large load batch size. This is stored in the `$streamEvents` variable.

On the second run, another bunch of events with 320 MB of RAM will be loaded and freeing up the `$streamEvents` variable is to late. That's why it should be cleaned up at the beginning of the each run.