### PR TITLE
Fix MysqlEventStore checking if stream exists for php8.1

### DIFF
--- a/src/MySqlEventStore.php
+++ b/src/MySqlEventStore.php
@@ -190,7 +190,7 @@ EOT;
             throw RuntimeException::fromStatementErrorInfo($statement->errorInfo());
         }
 
-        return '1' === $statement->fetchColumn();
+        return 1 === (int)$statement->fetchColumn();
     }
 
     public function create(Stream $stream): void


### PR DESCRIPTION
The return of the pdo statement when executing `$statement->fetchColumn()` in php8.1 is an integer. So the `'1' === $statement->fetchColumn();` will fail. 

Since we check if we got 1 or 0, which is always a number, casting to int makes it a more secure check.