### PR TITLE
Allow int return values from GET_LOCK MySQL function

### DIFF
--- a/src/WriteLockStrategy/MysqlMetadataLockStrategy.php
+++ b/src/WriteLockStrategy/MysqlMetadataLockStrategy.php
@@ -51,7 +51,7 @@ final class MysqlMetadataLockStrategy implements WriteLockStrategy
         }
 
         $lockStatus = $res->fetchAll();
-        if ('1' === $lockStatus[0]['get_lock']) {
+        if ('1' === $lockStatus[0]['get_lock'] || 1 === $lockStatus[0]['get_lock']) {
             return true;
         }
 

--- a/tests/WriteLockStrategy/MysqlMetadataLockStrategyTest.php
+++ b/tests/WriteLockStrategy/MysqlMetadataLockStrategyTest.php
@@ -47,6 +47,25 @@ class MysqlMetadataLockStrategyTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_true_when_lock_successful_int()
+    {
+        $statement = $this->prophesize(\PDOStatement::class);
+        $statement->fetchAll()->willReturn([
+            0 => ['get_lock' => 1],
+        ]);
+
+        $connection = $this->prophesize(\PDO::class);
+
+        $connection->query(Argument::any())->willReturn($statement->reveal());
+
+        $strategy = new MysqlMetadataLockStrategy($connection->reveal());
+
+        $this->assertTrue($strategy->getLock('lock'));
+    }
+
+    /**
+     * @test
+     */
     public function it_requests_lock_with_given_name()
     {
         $statement = $this->prophesize(\PDOStatement::class);
@@ -129,6 +148,25 @@ class MysqlMetadataLockStrategyTest extends TestCase
         $statement = $this->prophesize(\PDOStatement::class);
         $statement->fetchAll()->willReturn([
             0 => ['get_lock' => '0'],
+        ]);
+
+        $connection = $this->prophesize(\PDO::class);
+
+        $connection->query(Argument::any())->willReturn($statement->reveal());
+
+        $strategy = new MysqlMetadataLockStrategy($connection->reveal());
+
+        $this->assertFalse($strategy->getLock('lock'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_on_lock_failure_int()
+    {
+        $statement = $this->prophesize(\PDOStatement::class);
+        $statement->fetchAll()->willReturn([
+            0 => ['get_lock' => 0],
         ]);
 
         $connection = $this->prophesize(\PDO::class);


### PR DESCRIPTION
After updating our application to PHP 8.1 and updating our dependencies, all functions that tried to save our event store models failed because of a failure to get a lock. It seems like either the PHP update or an update of a doctrine library changed the return value of the GET_LOCK MySQL function to return int instead of a string.