### PR TITLE
fix(mariadb): hasStream failed to detect existing stream

### DIFF
--- a/src/MariaDbEventStore.php
+++ b/src/MariaDbEventStore.php
@@ -190,7 +190,7 @@ EOT;
             throw RuntimeException::fromStatementErrorInfo($statement->errorInfo());
         }
 
-        return '1' === $statement->fetchColumn();
+        return 1 === (int) $statement->fetchColumn();
     }
 
     public function create(Stream $stream): void


### PR DESCRIPTION
Compare operation fails when `$statement->fetchColumn()` returns a numeric value
fix #240 