### PR TITLE
Introduce GapDetector interface to allow custom implementations

### DIFF
--- a/src/Projection/GapDetection.php
+++ b/src/Projection/GapDetection.php
@@ -25,7 +25,7 @@ use Prooph\Common\Messaging\Message;
  *
  * @package Prooph\EventStore\Pdo\Projection
  */
-final class GapDetection
+final class GapDetection implements GapDetector
 {
     /**
      * If gap still exists after all retries, projector moves on

--- a/src/Projection/GapDetector.php
+++ b/src/Projection/GapDetector.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of prooph/pdo-event-store.
+ * (c) 2016-2025 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2016-2025 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Pdo\Projection;
+
+use DateTimeImmutable;
+use Prooph\Common\Messaging\Message;
+
+/**
+ * @see GapDetection for a default implemenation
+ */
+interface GapDetector
+{
+    public function isRetrying(): bool;
+
+    public function trackRetry(): void;
+
+    public function resetRetries(): void;
+
+    public function getSleepForNextRetry(): int;
+
+    public function isGapInStreamPosition(int $streamPosition, int $eventPosition): bool;
+
+    public function shouldRetryToFillGap(DateTimeImmutable $now, Message $currentMessage): bool;
+}


### PR DESCRIPTION
This enables actively tracking how often gaps occur, how many retries are needed to fill the gaps and f.e. log a warning when a permanent gap occurs.

Unfortunately that is quite difficult with the current closed GapDetection class. An easy way would be to undo marking the GapDection class as final to allow extending it in user land code. I guess the proper way would be to add a GapDetector interface.

The latter is what I propose in this PR. It should be backwards compatible.